### PR TITLE
Add block type catalog and schema refactor

### DIFF
--- a/backend/alembic/versions/a1b2c3d4e5f6_add_block_types_catalog.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_add_block_types_catalog.py
@@ -1,0 +1,239 @@
+"""add_block_types_catalog
+
+Revision ID: a1b2c3d4e5f6
+Revises: f0612b1838c1
+Create Date: 2026-01-27 10:00:00.000000
+
+"""
+from datetime import datetime
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+
+
+# revision identifiers, used by Alembic.
+revision = 'a1b2c3d4e5f6'
+down_revision = 'f0612b1838c1'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1. Create block_types table
+    op.create_table(
+        'block_types',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('slug', sqlmodel.sql.sqltypes.AutoString(length=50), nullable=False),
+        sa.Column('label', sqlmodel.sql.sqltypes.AutoString(length=100), nullable=False),
+        sa.Column('description', sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column('default_duration_minutes', sa.Integer(), nullable=False, server_default='10'),
+        sa.Column('icon_key', sqlmodel.sql.sqltypes.AutoString(length=50), nullable=True),
+        sa.Column('display_order', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('is_system', sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column('user_id', sa.Integer(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id']),
+    )
+    op.create_index(op.f('ix_block_types_slug'), 'block_types', ['slug'], unique=True)
+
+    # 2. Add block_type_id and duration_minutes to exercise_blocks
+    op.add_column('exercise_blocks', sa.Column('block_type_id', sa.Integer(), nullable=True))
+    op.add_column('exercise_blocks', sa.Column('duration_minutes', sa.Integer(), nullable=True))
+    op.create_foreign_key(
+        'fk_exercise_blocks_block_type_id',
+        'exercise_blocks', 'block_types',
+        ['block_type_id'], ['id']
+    )
+
+    # 3. Seed system block types
+    block_types_table = sa.table(
+        'block_types',
+        sa.column('id', sa.Integer),
+        sa.column('slug', sa.String),
+        sa.column('label', sa.String),
+        sa.column('description', sa.String),
+        sa.column('default_duration_minutes', sa.Integer),
+        sa.column('icon_key', sa.String),
+        sa.column('display_order', sa.Integer),
+        sa.column('is_system', sa.Boolean),
+        sa.column('user_id', sa.Integer),
+        sa.column('created_at', sa.DateTime),
+    )
+    op.bulk_insert(block_types_table, [
+        {
+            'slug': 'warmup',
+            'label': 'Warm-up',
+            'description': 'Warm-up exercises to prepare for practice',
+            'default_duration_minutes': 5,
+            'icon_key': 'clock',
+            'display_order': 1,
+            'is_system': True,
+            'user_id': None,
+            'created_at': datetime.utcnow(),
+        },
+        {
+            'slug': 'scales',
+            'label': 'Scales & Arpeggios',
+            'description': 'Scale and arpeggio practice',
+            'default_duration_minutes': 10,
+            'icon_key': 'music',
+            'display_order': 2,
+            'is_system': True,
+            'user_id': None,
+            'created_at': datetime.utcnow(),
+        },
+        {
+            'slug': 'technique',
+            'label': 'Technical Focus',
+            'description': 'Technical exercises and etudes',
+            'default_duration_minutes': 12,
+            'icon_key': 'target',
+            'display_order': 3,
+            'is_system': True,
+            'user_id': None,
+            'created_at': datetime.utcnow(),
+        },
+        {
+            'slug': 'repertoire',
+            'label': 'Repertoire',
+            'description': 'Repertoire practice and performance preparation',
+            'default_duration_minutes': 15,
+            'icon_key': 'book-open',
+            'display_order': 4,
+            'is_system': True,
+            'user_id': None,
+            'created_at': datetime.utcnow(),
+        },
+        {
+            'slug': 'sight_reading',
+            'label': 'Sight Reading',
+            'description': 'Sight reading exercises',
+            'default_duration_minutes': 10,
+            'icon_key': 'eye',
+            'display_order': 5,
+            'is_system': True,
+            'user_id': None,
+            'created_at': datetime.utcnow(),
+        },
+        {
+            'slug': 'cool_down',
+            'label': 'Cool Down',
+            'description': 'Cool down and reflection',
+            'default_duration_minutes': 5,
+            'icon_key': 'sunset',
+            'display_order': 6,
+            'is_system': True,
+            'user_id': None,
+            'created_at': datetime.utcnow(),
+        },
+    ])
+
+    # 4. Data migration: set block_type_id for existing blockA/blockB rows to "technique"
+    conn = op.get_bind()
+    technique_id = conn.execute(
+        sa.text("SELECT id FROM block_types WHERE slug = 'technique'")
+    ).scalar()
+    warmup_id = conn.execute(
+        sa.text("SELECT id FROM block_types WHERE slug = 'warmup'")
+    ).scalar()
+    scales_id = conn.execute(
+        sa.text("SELECT id FROM block_types WHERE slug = 'scales'")
+    ).scalar()
+    repertoire_id = conn.execute(
+        sa.text("SELECT id FROM block_types WHERE slug = 'repertoire'")
+    ).scalar()
+
+    # Set block_type_id = technique for all existing exercise_blocks (blockA/blockB)
+    conn.execute(
+        sa.text("UPDATE exercise_blocks SET block_type_id = :tid WHERE block_type_id IS NULL"),
+        {'tid': technique_id}
+    )
+
+    # 5. For each practice_day with warmup/scales/repertoire text, create exercise_block + exercise rows
+    days = conn.execute(sa.text(
+        "SELECT id, warmup, scales, repertoire FROM practice_days"
+    )).fetchall()
+
+    for day in days:
+        day_id, warmup_text, scales_text, repertoire_text = day
+
+        # Get current max display_order for this day
+        max_order = conn.execute(sa.text(
+            "SELECT COALESCE(MAX(display_order), 0) FROM exercise_blocks WHERE practice_day_id = :did"
+        ), {'did': day_id}).scalar()
+
+        if warmup_text:
+            # Create warmup block with display_order 0 (goes first)
+            conn.execute(sa.text(
+                "INSERT INTO exercise_blocks (practice_day_id, block_type, block_type_id, display_order) "
+                "VALUES (:did, 'warmup', :btid, 0)"
+            ), {'did': day_id, 'btid': warmup_id})
+            warmup_block_id = conn.execute(sa.text(
+                "SELECT id FROM exercise_blocks WHERE practice_day_id = :did AND block_type = 'warmup' ORDER BY id DESC LIMIT 1"
+            ), {'did': day_id}).scalar()
+            conn.execute(sa.text(
+                "INSERT INTO exercises (block_id, exercise_text, display_order) "
+                "VALUES (:bid, :txt, 1)"
+            ), {'bid': warmup_block_id, 'txt': warmup_text})
+
+        if scales_text:
+            # Create scales block with display_order 1
+            conn.execute(sa.text(
+                "INSERT INTO exercise_blocks (practice_day_id, block_type, block_type_id, display_order) "
+                "VALUES (:did, 'scales', :btid, 1)"
+            ), {'did': day_id, 'btid': scales_id})
+            scales_block_id = conn.execute(sa.text(
+                "SELECT id FROM exercise_blocks WHERE practice_day_id = :did AND block_type = 'scales' ORDER BY id DESC LIMIT 1"
+            ), {'did': day_id}).scalar()
+            conn.execute(sa.text(
+                "INSERT INTO exercises (block_id, exercise_text, display_order) "
+                "VALUES (:bid, :txt, 1)"
+            ), {'bid': scales_block_id, 'txt': scales_text})
+
+        if repertoire_text:
+            # Create repertoire block with display_order 100 (goes last)
+            conn.execute(sa.text(
+                "INSERT INTO exercise_blocks (practice_day_id, block_type, block_type_id, display_order) "
+                "VALUES (:did, 'repertoire', :btid, 100)"
+            ), {'did': day_id, 'btid': repertoire_id})
+            repertoire_block_id = conn.execute(sa.text(
+                "SELECT id FROM exercise_blocks WHERE practice_day_id = :did AND block_type = 'repertoire' ORDER BY id DESC LIMIT 1"
+            ), {'did': day_id}).scalar()
+            conn.execute(sa.text(
+                "INSERT INTO exercises (block_id, exercise_text, display_order) "
+                "VALUES (:bid, :txt, 1)"
+            ), {'bid': repertoire_block_id, 'txt': repertoire_text})
+
+    # 6. Reorder existing blockA/blockB display_order to 3 and 4
+    conn.execute(sa.text(
+        "UPDATE exercise_blocks SET display_order = 3 WHERE block_type = 'blockA'"
+    ))
+    conn.execute(sa.text(
+        "UPDATE exercise_blocks SET display_order = 4 WHERE block_type = 'blockB'"
+    ))
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    # Remove exercise_blocks created by the data migration (warmup, scales, repertoire block_type)
+    # First remove their exercises, then the blocks themselves
+    conn.execute(sa.text(
+        "DELETE FROM exercises WHERE block_id IN "
+        "(SELECT id FROM exercise_blocks WHERE block_type IN ('warmup', 'scales', 'repertoire'))"
+    ))
+    conn.execute(sa.text(
+        "DELETE FROM exercise_blocks WHERE block_type IN ('warmup', 'scales', 'repertoire')"
+    ))
+
+    # Restore original display_order for blockA/blockB
+    conn.execute(sa.text("UPDATE exercise_blocks SET display_order = 1 WHERE block_type = 'blockA'"))
+    conn.execute(sa.text("UPDATE exercise_blocks SET display_order = 2 WHERE block_type = 'blockB'"))
+
+    # Drop FK, columns, table
+    op.drop_constraint('fk_exercise_blocks_block_type_id', 'exercise_blocks', type_='foreignkey')
+    op.drop_column('exercise_blocks', 'duration_minutes')
+    op.drop_column('exercise_blocks', 'block_type_id')
+    op.drop_index(op.f('ix_block_types_slug'), table_name='block_types')
+    op.drop_table('block_types')

--- a/backend/app/api/block_types.py
+++ b/backend/app/api/block_types.py
@@ -1,0 +1,27 @@
+from fastapi import APIRouter, Depends
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+from typing import List
+
+from app.database import get_session
+from app.models import BlockType, User
+from app.auth import get_current_user
+
+router = APIRouter(prefix="/block-types", tags=["block-types"])
+
+
+@router.get("/", response_model=List[BlockType])
+async def list_block_types(
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user)
+):
+    """Get all block types (system + user-owned), ordered by display_order."""
+    statement = (
+        select(BlockType)
+        .where(
+            (BlockType.is_system == True) | (BlockType.user_id == current_user.id)
+        )
+        .order_by(BlockType.display_order)
+    )
+    result = await session.exec(statement)
+    return result.all()

--- a/backend/app/api/templates.py
+++ b/backend/app/api/templates.py
@@ -93,10 +93,12 @@ async def get_template(
                 "id": block.id,
                 "practice_day_id": block.practice_day_id,
                 "block_type": block.block_type,
+                "block_type_id": block.block_type_id,
+                "duration_minutes": block.duration_minutes,
                 "display_order": block.display_order,
                 "exercises": []
             }
-            
+
             for ex in sorted(block.exercises, key=lambda x: x.display_order):
                 block_data["exercises"].append({
                     "id": ex.id,
@@ -104,11 +106,11 @@ async def get_template(
                     "exercise_text": ex.exercise_text,
                     "display_order": ex.display_order
                 })
-            
+
             day_data["exercise_blocks"].append(block_data)
-        
+
         response["practice_days"].append(day_data)
-    
+
     return response
 
 
@@ -170,10 +172,12 @@ async def get_practice_day(
             "id": block.id,
             "practice_day_id": block.practice_day_id,
             "block_type": block.block_type,
+            "block_type_id": block.block_type_id,
+            "duration_minutes": block.duration_minutes,
             "display_order": block.display_order,
             "exercises": []
         }
-        
+
         for ex in sorted(block.exercises, key=lambda x: x.display_order):
             block_data["exercises"].append({
                 "id": ex.id,
@@ -181,9 +185,9 @@ async def get_practice_day(
                 "exercise_text": ex.exercise_text,
                 "display_order": ex.display_order
             })
-        
+
         response["exercise_blocks"].append(block_data)
-    
+
     return response
 
 
@@ -247,6 +251,8 @@ async def copy_template(
             user_block = ExerciseBlock(
                 practice_day_id=user_day.id,
                 block_type=block.block_type,
+                block_type_id=block.block_type_id,
+                duration_minutes=block.duration_minutes,
                 display_order=block.display_order
             )
             session.add(user_block)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.config import get_settings
-from app.api import instruments, templates, logs, analytics, user
+from app.api import instruments, templates, logs, analytics, user, block_types
 
 settings = get_settings()
 
@@ -26,6 +26,7 @@ app.include_router(templates.router, prefix="/api")
 app.include_router(logs.router, prefix="/api")
 app.include_router(analytics.router, prefix="/api")
 app.include_router(user.router, prefix="/api")
+app.include_router(block_types.router, prefix="/api")
 
 
 @app.get("/")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -63,6 +63,25 @@ class PracticeTemplate(SQLModel, table=True):
     practice_logs: List["PracticeLog"] = Relationship(back_populates="template")
 
 
+class BlockType(SQLModel, table=True):
+    """Catalog of practice block categories (warm-up, scales, technique, etc.)"""
+    __tablename__ = "block_types"  # type: ignore[assignment]
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    slug: str = Field(max_length=50, unique=True, index=True)
+    label: str = Field(max_length=100)
+    description: Optional[str] = None
+    default_duration_minutes: int = Field(default=10)
+    icon_key: Optional[str] = Field(default=None, max_length=50)
+    display_order: int = Field(default=0)
+    is_system: bool = Field(default=True)
+    user_id: Optional[int] = Field(default=None, foreign_key="users.id")
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+    # Relationships
+    exercise_blocks: List["ExerciseBlock"] = Relationship(back_populates="block_type_rel")
+
+
 class PracticeDay(SQLModel, table=True):
     """Individual day in a practice template"""
     __tablename__ = "practice_days"  # type: ignore[assignment]
@@ -87,12 +106,15 @@ class ExerciseBlock(SQLModel, table=True):
     
     id: Optional[int] = Field(default=None, primary_key=True)
     practice_day_id: int = Field(foreign_key="practice_days.id")
-    block_type: str = Field(max_length=50)  # e.g., "blockA", "blockB"
+    block_type: str = Field(max_length=50)  # e.g., "blockA", "blockB" — kept for backward compat
+    block_type_id: Optional[int] = Field(default=None, foreign_key="block_types.id")
+    duration_minutes: Optional[int] = Field(default=None)
     display_order: int
     updated_at: Optional[datetime] = Field(default=None, sa_column_kwargs={"onupdate": datetime.utcnow})
-    
+
     # Relationships
     practice_day: Optional[PracticeDay] = Relationship(back_populates="exercise_blocks")
+    block_type_rel: Optional["BlockType"] = Relationship(back_populates="exercise_blocks")
     exercises: List["Exercise"] = Relationship(back_populates="block", sa_relationship_kwargs={"cascade": "all, delete-orphan"})
 
 

--- a/backend/seed_data.py
+++ b/backend/seed_data.py
@@ -12,7 +12,7 @@ sys.path.insert(0, str(backend_dir))
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 from app.database import async_session
-from app.models import Instrument, PracticeTemplate, PracticeDay, ExerciseBlock, Exercise
+from app.models import Instrument, PracticeTemplate, PracticeDay, ExerciseBlock, Exercise, BlockType
 
 # Violin rotation data extracted from HTML prototype
 ROTATION_DATA = {
@@ -268,11 +268,16 @@ async def seed_database():
             await session.flush()
             assert template.id is not None  # Type narrowing for type checker
         
+            # Look up block types by slug (seeded by migration)
+            print("Loading block types...")
+            bt_result = await session.execute(select(BlockType))
+            block_types_by_slug = {bt.slug: bt for bt in bt_result.scalars().all()}
+
             print("Populating practice days and exercises...")
             for day_num in range(1, 15):
                 day_data = ROTATION_DATA[day_num]
-                
-                # Create practice day
+
+                # Create practice day (keep deprecated text fields for frontend compat)
                 practice_day = PracticeDay(
                     template_id=template.id,
                     day_number=day_num,
@@ -284,45 +289,91 @@ async def seed_database():
                 session.add(practice_day)
                 await session.flush()
                 assert practice_day.id is not None  # Type narrowing for type checker
-                
-                # Create exercise block A
+
+                # Create warmup block
+                warmup_block = ExerciseBlock(
+                    practice_day_id=practice_day.id,
+                    block_type="warmup",
+                    block_type_id=block_types_by_slug["warmup"].id,
+                    display_order=0
+                )
+                session.add(warmup_block)
+                await session.flush()
+                assert warmup_block.id is not None
+                session.add(Exercise(
+                    block_id=warmup_block.id,
+                    exercise_text=day_data["warmup"],
+                    display_order=1
+                ))
+
+                # Create scales block
+                scales_block = ExerciseBlock(
+                    practice_day_id=practice_day.id,
+                    block_type="scales",
+                    block_type_id=block_types_by_slug["scales"].id,
+                    display_order=1
+                )
+                session.add(scales_block)
+                await session.flush()
+                assert scales_block.id is not None
+                session.add(Exercise(
+                    block_id=scales_block.id,
+                    exercise_text=day_data["scales"],
+                    display_order=1
+                ))
+
+                # Create exercise block A (technique)
                 block_a = ExerciseBlock(
                     practice_day_id=practice_day.id,
                     block_type="blockA",
-                    display_order=1
+                    block_type_id=block_types_by_slug["technique"].id,
+                    display_order=3
                 )
                 session.add(block_a)
                 await session.flush()
-                assert block_a.id is not None  # Type narrowing for type checker
-                
-                # Add exercises to block A
+                assert block_a.id is not None
+
                 for idx, exercise_text in enumerate(day_data["blockA"], start=1):
-                    exercise = Exercise(
+                    session.add(Exercise(
                         block_id=block_a.id,
                         exercise_text=exercise_text,
                         display_order=idx
-                    )
-                    session.add(exercise)
-                
-                # Create exercise block B
+                    ))
+
+                # Create exercise block B (technique)
                 block_b = ExerciseBlock(
                     practice_day_id=practice_day.id,
                     block_type="blockB",
-                    display_order=2
+                    block_type_id=block_types_by_slug["technique"].id,
+                    display_order=4
                 )
                 session.add(block_b)
                 await session.flush()
-                assert block_b.id is not None  # Type narrowing for type checker
-                
-                # Add exercises to block B
+                assert block_b.id is not None
+
                 for idx, exercise_text in enumerate(day_data["blockB"], start=1):
-                    exercise = Exercise(
+                    session.add(Exercise(
                         block_id=block_b.id,
                         exercise_text=exercise_text,
                         display_order=idx
-                    )
-                    session.add(exercise)
-                
+                    ))
+
+                # Create repertoire block
+                repertoire_block = ExerciseBlock(
+                    practice_day_id=practice_day.id,
+                    block_type="repertoire",
+                    block_type_id=block_types_by_slug["repertoire"].id,
+                    display_order=100
+                )
+                session.add(repertoire_block)
+                await session.flush()
+                assert repertoire_block.id is not None
+                session.add(Exercise(
+                    block_id=repertoire_block.id,
+                    exercise_text=day_data["repertoire"],
+                    display_order=1
+                ))
+
                 print(f"  Added Day {day_num}: {day_data['title']}")
             
             await session.commit()


### PR DESCRIPTION
Introduce a block_types table to define practice block categories (warm-up, scales, technique, repertoire, sight reading, cool down) and link exercise_blocks to them via block_type_id. Migrate existing data so warmup/scales/repertoire text fields also exist as proper blocks. Old text fields and block_type string column are retained for frontend backward compatibility.

- Add BlockType model with slug, label, duration, icon, display_order
- Add block_type_id and duration_minutes to ExerciseBlock
- Alembic migration: create table, seed 6 types, migrate existing data
- New GET /api/block-types/ endpoint
- Update template API responses and copy to include new fields
- Update seed script to create all block types