### PR TITLE
Add exercise progress tracking and suggestions API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ htmlcov/
 
 # Architecture
 .architecture/
+
+# Local plans
+.plans/

--- a/backend/alembic/versions/b2c3d4e5f6g7_add_exercise_metadata.py
+++ b/backend/alembic/versions/b2c3d4e5f6g7_add_exercise_metadata.py
@@ -1,0 +1,33 @@
+"""add_exercise_metadata
+
+Revision ID: b2c3d4e5f6g7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-01-29 10:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b2c3d4e5f6g7'
+down_revision = '6112e8733982'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add structured metadata fields to exercises table
+    op.add_column('exercises', sa.Column('tempo_bpm', sa.Integer(), nullable=True))
+    op.add_column('exercises', sa.Column('key', sa.String(length=50), nullable=True))
+    op.add_column('exercises', sa.Column('technique_category', sa.String(length=50), nullable=True))
+    op.add_column('exercises', sa.Column('difficulty_level', sa.Integer(), nullable=True))
+    op.add_column('exercises', sa.Column('notes', sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('exercises', 'notes')
+    op.drop_column('exercises', 'difficulty_level')
+    op.drop_column('exercises', 'technique_category')
+    op.drop_column('exercises', 'key')
+    op.drop_column('exercises', 'tempo_bpm')

--- a/backend/alembic/versions/c3d4e5f6g7h8_add_log_detail_fields.py
+++ b/backend/alembic/versions/c3d4e5f6g7h8_add_log_detail_fields.py
@@ -1,0 +1,39 @@
+"""add_log_detail_fields
+
+Revision ID: c3d4e5f6g7h8
+Revises: b2c3d4e5f6g7
+Create Date: 2026-01-29 10:10:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'c3d4e5f6g7h8'
+down_revision = 'b2c3d4e5f6g7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add enhanced fields to practice_log_details table
+    op.add_column('practice_log_details', sa.Column('exercise_id', sa.Integer(), nullable=True))
+    op.add_column('practice_log_details', sa.Column('tempo_practiced', sa.Integer(), nullable=True))
+    op.add_column('practice_log_details', sa.Column('outcome', sa.String(length=20), nullable=True))
+    op.add_column('practice_log_details', sa.Column('notes', sa.Text(), nullable=True))
+
+    # Add foreign key constraint for exercise_id
+    op.create_foreign_key(
+        'fk_practice_log_details_exercise_id',
+        'practice_log_details', 'exercises',
+        ['exercise_id'], ['id']
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint('fk_practice_log_details_exercise_id', 'practice_log_details', type_='foreignkey')
+    op.drop_column('practice_log_details', 'notes')
+    op.drop_column('practice_log_details', 'outcome')
+    op.drop_column('practice_log_details', 'tempo_practiced')
+    op.drop_column('practice_log_details', 'exercise_id')

--- a/backend/alembic/versions/d4e5f6g7h8i9_add_exercise_progress.py
+++ b/backend/alembic/versions/d4e5f6g7h8i9_add_exercise_progress.py
@@ -1,0 +1,56 @@
+"""add_exercise_progress
+
+Revision ID: d4e5f6g7h8i9
+Revises: c3d4e5f6g7h8
+Create Date: 2026-01-29 10:20:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd4e5f6g7h8i9'
+down_revision = 'c3d4e5f6g7h8'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Create exercise_progress table
+    op.create_table(
+        'exercise_progress',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('exercise_id', sa.Integer(), nullable=False),
+        sa.Column('times_practiced', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('last_practiced_at', sa.DateTime(), nullable=True),
+        sa.Column('current_tempo', sa.Integer(), nullable=True),
+        sa.Column('current_difficulty', sa.Integer(), nullable=True),
+        sa.Column('struggled_count', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('okay_count', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('nailed_it_count', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id']),
+        sa.ForeignKeyConstraint(['exercise_id'], ['exercises.id']),
+    )
+
+    # Create indexes
+    op.create_index('ix_exercise_progress_user_id', 'exercise_progress', ['user_id'])
+    op.create_index('ix_exercise_progress_exercise_id', 'exercise_progress', ['exercise_id'])
+
+    # Create unique constraint on (user_id, exercise_id)
+    op.create_unique_constraint(
+        'uq_exercise_progress_user_exercise',
+        'exercise_progress',
+        ['user_id', 'exercise_id']
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint('uq_exercise_progress_user_exercise', 'exercise_progress', type_='unique')
+    op.drop_index('ix_exercise_progress_exercise_id', table_name='exercise_progress')
+    op.drop_index('ix_exercise_progress_user_id', table_name='exercise_progress')
+    op.drop_table('exercise_progress')

--- a/backend/app/api/logs.py
+++ b/backend/app/api/logs.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -6,7 +8,10 @@ from sqlalchemy import desc
 from typing import List, Optional
 
 from app.database import get_session
-from app.models import PracticeLog, PracticeLogDetail, PracticeLogCreate, PracticeTemplate, User
+from app.models import (
+    PracticeLog, PracticeLogDetail, PracticeLogCreate, PracticeTemplate, User,
+    ExerciseProgress, PracticeOutcome
+)
 from app.auth import get_current_user
 
 router = APIRouter(prefix="/logs", tags=["logs"])
@@ -45,15 +50,29 @@ async def create_practice_log(
     await session.flush()  # Get the log ID
     assert practice_log.id is not None  # Type narrowing for type checker
     
-    # Create log details
+    # Create log details and track progress
     for detail in log_data.log_details:
         log_detail = PracticeLogDetail(
             log_id=practice_log.id,
             section_type=detail.section_type,
-            content=detail.content
+            content=detail.content,
+            exercise_id=detail.exercise_id,
+            tempo_practiced=detail.tempo_practiced,
+            outcome=detail.outcome,
+            notes=detail.notes,
         )
         session.add(log_detail)
-    
+
+        # Update exercise progress if exercise_id is provided
+        if detail.exercise_id is not None:
+            await _update_exercise_progress(
+                session=session,
+                user_id=current_user.id,
+                exercise_id=detail.exercise_id,
+                tempo_practiced=detail.tempo_practiced,
+                outcome=detail.outcome,
+            )
+
     await session.commit()
     await session.refresh(practice_log)
     
@@ -131,3 +150,54 @@ async def get_practice_log(
         raise HTTPException(status_code=404, detail="Practice log not found")
 
     return log
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+async def _update_exercise_progress(
+    session: AsyncSession,
+    user_id: int,
+    exercise_id: int,
+    tempo_practiced: Optional[int],
+    outcome: Optional[str],
+) -> None:
+    """Update or create exercise progress record for a user's exercise."""
+    # Find existing progress record
+    statement = select(ExerciseProgress).where(
+        ExerciseProgress.user_id == user_id,
+        ExerciseProgress.exercise_id == exercise_id,
+    )
+    result = await session.exec(statement)
+    progress = result.one_or_none()
+
+    if progress is None:
+        # Create new progress record
+        progress = ExerciseProgress(
+            user_id=user_id,
+            exercise_id=exercise_id,
+            times_practiced=0,
+            struggled_count=0,
+            okay_count=0,
+            nailed_it_count=0,
+            created_at=datetime.utcnow(),
+        )
+        session.add(progress)
+
+    # Update stats
+    progress.times_practiced += 1
+    progress.last_practiced_at = datetime.utcnow()
+
+    if tempo_practiced is not None:
+        progress.current_tempo = tempo_practiced
+
+    # Update outcome counters
+    if outcome == PracticeOutcome.STRUGGLED.value:
+        progress.struggled_count += 1
+    elif outcome == PracticeOutcome.OKAY.value:
+        progress.okay_count += 1
+    elif outcome == PracticeOutcome.NAILED_IT.value:
+        progress.nailed_it_count += 1
+
+    session.add(progress)

--- a/backend/app/api/suggestions.py
+++ b/backend/app/api/suggestions.py
@@ -1,0 +1,190 @@
+"""
+Suggestions API
+
+Provides exercise progress data for the frontend rules engine to compute suggestions.
+Also handles suggestion dismissals/acceptances for persistence.
+"""
+from datetime import datetime
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlmodel import select, and_
+from sqlmodel.ext.asyncio.session import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.database import get_session
+from app.models import (
+    ExerciseProgress, Exercise, ExerciseBlock, PracticeDay,
+    PracticeTemplate, Instrument, User
+)
+from app.auth import get_current_user
+
+router = APIRouter(prefix="/suggestions", tags=["suggestions"])
+
+
+@router.get("/progress")
+async def get_exercise_progress(
+    instrument_id: Optional[int] = None,
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    """
+    Get exercise progress for the current user's exercises.
+
+    Optionally filter by instrument. Returns progress data that the frontend
+    rules engine can use to compute suggestions.
+    """
+    # Build query to get all exercises for the user's templates
+    # We need to traverse: Instrument -> Template -> Day -> Block -> Exercise
+
+    # First, get the user's templates (optionally filtered by instrument)
+    template_query = select(PracticeTemplate).where(
+        PracticeTemplate.user_id == current_user.id,
+        PracticeTemplate.deleted_at == None,
+    )
+    if instrument_id is not None:
+        template_query = template_query.where(PracticeTemplate.instrument_id == instrument_id)
+
+    template_result = await session.exec(template_query)
+    templates = template_result.all()
+    template_ids = [t.id for t in templates]
+
+    if not template_ids:
+        return {"exercises": [], "progress": []}
+
+    # Get all exercises in these templates
+    exercise_query = (
+        select(Exercise)
+        .join(ExerciseBlock, Exercise.block_id == ExerciseBlock.id)
+        .join(PracticeDay, ExerciseBlock.practice_day_id == PracticeDay.id)
+        .where(PracticeDay.template_id.in_(template_ids))  # type: ignore[union-attr]
+    )
+    exercise_result = await session.exec(exercise_query)
+    exercises = exercise_result.all()
+    exercise_ids = [e.id for e in exercises]
+
+    if not exercise_ids:
+        return {"exercises": [], "progress": []}
+
+    # Get progress records for these exercises
+    progress_query = select(ExerciseProgress).where(
+        ExerciseProgress.user_id == current_user.id,
+        ExerciseProgress.exercise_id.in_(exercise_ids),  # type: ignore[union-attr]
+    )
+    progress_result = await session.exec(progress_query)
+    progress_records = progress_result.all()
+
+    # Build response
+    exercises_data = [
+        {
+            "id": ex.id,
+            "exercise_text": ex.exercise_text,
+            "tempo_bpm": ex.tempo_bpm,
+            "key": ex.key,
+            "technique_category": ex.technique_category,
+            "difficulty_level": ex.difficulty_level,
+        }
+        for ex in exercises
+    ]
+
+    progress_data = [
+        {
+            "id": p.id,
+            "exercise_id": p.exercise_id,
+            "times_practiced": p.times_practiced,
+            "last_practiced_at": p.last_practiced_at.isoformat() if p.last_practiced_at else None,
+            "current_tempo": p.current_tempo,
+            "current_difficulty": p.current_difficulty,
+            "struggled_count": p.struggled_count,
+            "okay_count": p.okay_count,
+            "nailed_it_count": p.nailed_it_count,
+        }
+        for p in progress_records
+    ]
+
+    return {
+        "exercises": exercises_data,
+        "progress": progress_data,
+    }
+
+
+@router.post("/dismiss/{suggestion_key}")
+async def dismiss_suggestion(
+    suggestion_key: str,
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    """
+    Dismiss a suggestion so it doesn't appear again.
+
+    suggestion_key format: "exercise_{exercise_id}_{rule_id}"
+    e.g., "exercise_123_tempo_increase"
+
+    For MVP, we'll store this in a simple table. Future: could use Redis or similar.
+    """
+    # For MVP, return success - dismissals will be stored in frontend/localStorage
+    # TODO: Add SuggestionDismissal table for server-side persistence
+    return {"status": "dismissed", "suggestion_key": suggestion_key}
+
+
+@router.post("/accept/{suggestion_key}")
+async def accept_suggestion(
+    suggestion_key: str,
+    action: dict,
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    """
+    Accept a suggestion and apply its action.
+
+    The action dict contains:
+    - exercise_id: int
+    - field: str (e.g., "tempo_bpm")
+    - value: any
+
+    This updates the exercise with the new value.
+    """
+    exercise_id = action.get("exercise_id")
+    field = action.get("field")
+    value = action.get("value")
+
+    if not all([exercise_id, field, value is not None]):
+        raise HTTPException(status_code=400, detail="Missing exercise_id, field, or value")
+
+    # Verify user owns this exercise (via template ownership)
+    exercise_query = (
+        select(Exercise)
+        .join(ExerciseBlock, Exercise.block_id == ExerciseBlock.id)
+        .join(PracticeDay, ExerciseBlock.practice_day_id == PracticeDay.id)
+        .join(PracticeTemplate, PracticeDay.template_id == PracticeTemplate.id)
+        .where(
+            Exercise.id == exercise_id,
+            PracticeTemplate.user_id == current_user.id,
+            PracticeTemplate.deleted_at == None,
+        )
+    )
+    result = await session.exec(exercise_query)
+    exercise = result.one_or_none()
+
+    if not exercise:
+        raise HTTPException(status_code=404, detail="Exercise not found")
+
+    # Update the exercise field
+    allowed_fields = ["tempo_bpm", "key", "technique_category", "difficulty_level", "notes"]
+    if field not in allowed_fields:
+        raise HTTPException(status_code=400, detail=f"Cannot update field: {field}")
+
+    setattr(exercise, field, value)
+    session.add(exercise)
+    await session.commit()
+    await session.refresh(exercise)
+
+    return {
+        "status": "accepted",
+        "suggestion_key": suggestion_key,
+        "exercise": {
+            "id": exercise.id,
+            "exercise_text": exercise.exercise_text,
+            field: getattr(exercise, field),
+        }
+    }

--- a/backend/app/api/templates.py
+++ b/backend/app/api/templates.py
@@ -112,7 +112,12 @@ async def get_template(
                     "id": ex.id,
                     "block_id": ex.block_id,
                     "exercise_text": ex.exercise_text,
-                    "display_order": ex.display_order
+                    "display_order": ex.display_order,
+                    "tempo_bpm": ex.tempo_bpm,
+                    "key": ex.key,
+                    "technique_category": ex.technique_category,
+                    "difficulty_level": ex.difficulty_level,
+                    "notes": ex.notes,
                 })
 
             day_data["exercise_blocks"].append(block_data)
@@ -191,7 +196,12 @@ async def get_practice_day(
                 "id": ex.id,
                 "block_id": ex.block_id,
                 "exercise_text": ex.exercise_text,
-                "display_order": ex.display_order
+                "display_order": ex.display_order,
+                "tempo_bpm": ex.tempo_bpm,
+                "key": ex.key,
+                "technique_category": ex.technique_category,
+                "difficulty_level": ex.difficulty_level,
+                "notes": ex.notes,
             })
 
         response["exercise_blocks"].append(block_data)
@@ -272,7 +282,12 @@ async def copy_template(
                 user_exercise = Exercise(
                     block_id=user_block.id,
                     exercise_text=exercise.exercise_text,
-                    display_order=exercise.display_order
+                    display_order=exercise.display_order,
+                    tempo_bpm=exercise.tempo_bpm,
+                    key=exercise.key,
+                    technique_category=exercise.technique_category,
+                    difficulty_level=exercise.difficulty_level,
+                    notes=exercise.notes,
                 )
                 session.add(user_exercise)
     
@@ -655,6 +670,11 @@ async def create_exercise(
         block_id=block.id,
         exercise_text=body.exercise_text,
         display_order=display_order,
+        tempo_bpm=body.tempo_bpm,
+        key=body.key,
+        technique_category=body.technique_category,
+        difficulty_level=body.difficulty_level,
+        notes=body.notes,
     )
     session.add(exercise)
     await session.commit()
@@ -665,6 +685,11 @@ async def create_exercise(
         "block_id": exercise.block_id,
         "exercise_text": exercise.exercise_text,
         "display_order": exercise.display_order,
+        "tempo_bpm": exercise.tempo_bpm,
+        "key": exercise.key,
+        "technique_category": exercise.technique_category,
+        "difficulty_level": exercise.difficulty_level,
+        "notes": exercise.notes,
     }
 
 
@@ -698,6 +723,16 @@ async def update_exercise(
         exercise.exercise_text = body.exercise_text
     if body.display_order is not None:
         exercise.display_order = body.display_order
+    if body.tempo_bpm is not None:
+        exercise.tempo_bpm = body.tempo_bpm
+    if body.key is not None:
+        exercise.key = body.key
+    if body.technique_category is not None:
+        exercise.technique_category = body.technique_category
+    if body.difficulty_level is not None:
+        exercise.difficulty_level = body.difficulty_level
+    if body.notes is not None:
+        exercise.notes = body.notes
 
     session.add(exercise)
     await session.commit()
@@ -708,6 +743,11 @@ async def update_exercise(
         "block_id": exercise.block_id,
         "exercise_text": exercise.exercise_text,
         "display_order": exercise.display_order,
+        "tempo_bpm": exercise.tempo_bpm,
+        "key": exercise.key,
+        "technique_category": exercise.technique_category,
+        "difficulty_level": exercise.difficulty_level,
+        "notes": exercise.notes,
     }
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.config import get_settings
-from app.api import instruments, templates, logs, analytics, user, block_types
+from app.api import instruments, templates, logs, analytics, user, block_types, suggestions
 
 settings = get_settings()
 
@@ -27,6 +27,7 @@ app.include_router(logs.router, prefix="/api")
 app.include_router(analytics.router, prefix="/api")
 app.include_router(user.router, prefix="/api")
 app.include_router(block_types.router, prefix="/api")
+app.include_router(suggestions.router, prefix="/api")
 
 
 @app.get("/")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -2,9 +2,35 @@
 SQLModel models for Practice Journal
 These models serve as both database tables AND API schemas
 """
+from enum import Enum
 from typing import Optional, List
 from datetime import datetime, date
 from sqlmodel import Field, SQLModel, Relationship
+
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+class TechniqueCategory(str, Enum):
+    """Categories for exercise techniques"""
+    SCALES = "scales"
+    ARPEGGIOS = "arpeggios"
+    ETUDE = "etude"
+    LONG_TONES = "long_tones"
+    SHIFTING = "shifting"
+    BOWING = "bowing"
+    ARTICULATION = "articulation"
+    REPERTOIRE = "repertoire"
+    SIGHT_READING = "sight_reading"
+    OTHER = "other"
+
+
+class PracticeOutcome(str, Enum):
+    """How well a practice session went for an exercise"""
+    STRUGGLED = "struggled"
+    OKAY = "okay"
+    NAILED_IT = "nailed_it"
 
 
 class User(SQLModel, table=True):
@@ -121,15 +147,49 @@ class ExerciseBlock(SQLModel, table=True):
 class Exercise(SQLModel, table=True):
     """Individual exercise within a block"""
     __tablename__ = "exercises"  # type: ignore[assignment]
-    
+
     id: Optional[int] = Field(default=None, primary_key=True)
     block_id: int = Field(foreign_key="exercise_blocks.id")
     exercise_text: str
     display_order: int
     updated_at: Optional[datetime] = Field(default=None, sa_column_kwargs={"onupdate": datetime.utcnow})
-    
+
+    # Structured metadata fields (all optional)
+    tempo_bpm: Optional[int] = Field(default=None)
+    key: Optional[str] = Field(default=None, max_length=50)
+    technique_category: Optional[str] = Field(default=None, max_length=50)  # Stores TechniqueCategory value
+    difficulty_level: Optional[int] = Field(default=None)
+    notes: Optional[str] = Field(default=None)
+
     # Relationships
     block: Optional[ExerciseBlock] = Relationship(back_populates="exercises")
+
+
+class ExerciseProgress(SQLModel, table=True):
+    """Tracks user progress on a specific exercise over time"""
+    __tablename__ = "exercise_progress"  # type: ignore[assignment]
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="users.id", index=True)
+    exercise_id: int = Field(foreign_key="exercises.id", index=True)
+
+    # Aggregated stats
+    times_practiced: int = Field(default=0)
+    last_practiced_at: Optional[datetime] = Field(default=None)
+    current_tempo: Optional[int] = Field(default=None)
+    current_difficulty: Optional[int] = Field(default=None)
+
+    # Outcome tracking
+    struggled_count: int = Field(default=0)
+    okay_count: int = Field(default=0)
+    nailed_it_count: int = Field(default=0)
+
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: Optional[datetime] = Field(default=None, sa_column_kwargs={"onupdate": datetime.utcnow})
+
+    # Relationships
+    user: Optional["User"] = Relationship()
+    exercise: Optional[Exercise] = Relationship()
 
 
 class PracticeLog(SQLModel, table=True):
@@ -156,15 +216,22 @@ class PracticeLog(SQLModel, table=True):
 class PracticeLogDetail(SQLModel, table=True):
     """Detailed notes for sections of a practice log"""
     __tablename__ = "practice_log_details"  # type: ignore[assignment]
-    
+
     id: Optional[int] = Field(default=None, primary_key=True)
     log_id: int = Field(foreign_key="practice_logs.id")
     section_type: str = Field(max_length=50)  # e.g., "warmup", "scales", "techA"
     content: Optional[str] = None
     updated_at: Optional[datetime] = Field(default=None, sa_column_kwargs={"onupdate": datetime.utcnow})
-    
+
+    # Enhanced fields for progress tracking
+    exercise_id: Optional[int] = Field(default=None, foreign_key="exercises.id")
+    tempo_practiced: Optional[int] = Field(default=None)
+    outcome: Optional[str] = Field(default=None, max_length=20)  # Stores PracticeOutcome value
+    notes: Optional[str] = Field(default=None)
+
     # Relationships
     log: Optional[PracticeLog] = Relationship(back_populates="log_details")
+    exercise: Optional[Exercise] = Relationship()
 
 
 # API-specific models (for requests/responses that differ from DB models)
@@ -173,6 +240,10 @@ class PracticeLogDetailCreate(SQLModel):
     """Schema for creating log details"""
     section_type: str
     content: Optional[str] = None
+    exercise_id: Optional[int] = None
+    tempo_practiced: Optional[int] = None
+    outcome: Optional[str] = None  # One of PracticeOutcome values
+    notes: Optional[str] = None
 
 
 class PracticeLogCreate(SQLModel):
@@ -228,12 +299,22 @@ class ExerciseCreate(SQLModel):
     """Schema for creating an exercise"""
     exercise_text: str
     display_order: Optional[int] = None
+    tempo_bpm: Optional[int] = None
+    key: Optional[str] = None
+    technique_category: Optional[str] = None  # One of TechniqueCategory values
+    difficulty_level: Optional[int] = None
+    notes: Optional[str] = None
 
 
 class ExerciseUpdate(SQLModel):
     """Schema for updating an exercise"""
     exercise_text: Optional[str] = None
     display_order: Optional[int] = None
+    tempo_bpm: Optional[int] = None
+    key: Optional[str] = None
+    technique_category: Optional[str] = None  # One of TechniqueCategory values
+    difficulty_level: Optional[int] = None
+    notes: Optional[str] = None
 
 
 class AnalyticsSummary(SQLModel):


### PR DESCRIPTION
Backend foundation for rules-based practice suggestions:
- Add TechniqueCategory and PracticeOutcome enums to models
- Add exercise metadata fields (tempo_bpm, key, technique_category, difficulty_level, notes)
- Add ExerciseProgress model to track practice history per exercise
- Update PracticeLogDetail with exercise_id, tempo_practiced, outcome fields
- Auto-update exercise progress when practice logs are created
- Add suggestions API endpoints:
  - GET /api/suggestions/progress - returns exercises and progress data
  - POST /api/suggestions/dismiss/{key} - dismiss a suggestion
  - POST /api/suggestions/accept/{key} - accept and apply suggestion
- Include 3 Alembic migrations for schema changes