### PR TITLE
Add frontend rules engine and suggestions UI

### DIFF
--- a/frontend/src/app/[instrument]/log/page.tsx
+++ b/frontend/src/app/[instrument]/log/page.tsx
@@ -3,18 +3,33 @@
 import { useEffect, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { useApi } from '@/lib/useApi'
-import type { PracticeTemplate, PracticeDay, BlockType, Exercise } from '@/lib/types'
+import OutcomeSelector from '@/components/OutcomeSelector'
+import SuggestionCard from '@/components/SuggestionCard'
+import { evaluateRules } from '@/lib/progressionRules'
+import type { PracticeTemplate, PracticeDay, BlockType, Exercise, PracticeOutcome, Suggestion, Instrument } from '@/lib/types'
+
+// Track exercise selection with outcome
+interface ExerciseSelection {
+  exerciseId: number
+  exerciseText: string
+  outcome?: PracticeOutcome
+  tempoPracticed?: number
+}
 
 export default function LogPracticePage() {
   const params = useParams()
   const router = useRouter()
   const api = useApi()
   const instrumentName = params.instrument as string
+  const [instrument, setInstrument] = useState<Instrument | null>(null)
   const [template, setTemplate] = useState<PracticeTemplate | null>(null)
   const [blockTypes, setBlockTypes] = useState<BlockType[]>([])
   const [loading, setLoading] = useState(true)
   const [submitting, setSubmitting] = useState(false)
   const [freeformMode, setFreeformMode] = useState(false)
+  const [showSuccess, setShowSuccess] = useState(false)
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([])
+  const [dismissedKeys, setDismissedKeys] = useState<Set<string>>(new Set())
 
   const [formData, setFormData] = useState({
     date: new Date().toISOString().split('T')[0],
@@ -23,6 +38,8 @@ export default function LogPracticePage() {
     notes: '',
   })
 
+  // Track exercise selections with outcomes (keyed by block id)
+  const [exerciseSelections, setExerciseSelections] = useState<Record<number, ExerciseSelection>>({})
   const [blockNotes, setBlockNotes] = useState<Record<number, string>>({})
 
   const [freeformSections, setFreeformSections] = useState<
@@ -38,6 +55,7 @@ export default function LogPracticePage() {
           (i) => i.name.toLowerCase() === instrumentName.toLowerCase()
         )
         if (inst) {
+          setInstrument(inst)
           const tmpl = allTemplates.find(
             (t) => t.instrument_id === inst.id && t.is_active
           )
@@ -61,9 +79,10 @@ export default function LogPracticePage() {
       })
   }, [instrumentName, api])
 
-  // Reset blockNotes when day changes
+  // Reset selections when day changes
   useEffect(() => {
     setBlockNotes({})
+    setExerciseSelections({})
   }, [formData.dayNumber])
 
   const getCurrentDay = (): PracticeDay | undefined => {
@@ -80,6 +99,34 @@ export default function LogPracticePage() {
     const bt = blockTypes.find((t) => t.slug === block.block_type)
     if (bt) return bt.label
     return block.block_type
+  }
+
+  const handleExerciseSelect = (blockId: number, exercise: Exercise | null) => {
+    if (!exercise) {
+      const { [blockId]: _, ...rest } = exerciseSelections
+      setExerciseSelections(rest)
+      return
+    }
+    setExerciseSelections({
+      ...exerciseSelections,
+      [blockId]: {
+        exerciseId: exercise.id,
+        exerciseText: exercise.exercise_text,
+        tempoPracticed: exercise.tempo_bpm,
+        outcome: exerciseSelections[blockId]?.outcome,
+      },
+    })
+  }
+
+  const handleOutcomeChange = (blockId: number, outcome: PracticeOutcome | undefined) => {
+    if (!exerciseSelections[blockId]) return
+    setExerciseSelections({
+      ...exerciseSelections,
+      [blockId]: {
+        ...exerciseSelections[blockId],
+        outcome,
+      },
+    })
   }
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -102,24 +149,54 @@ export default function LogPracticePage() {
         })
       } else {
         const currentDay = getCurrentDay()
+        // Build log details with exercise outcomes
+        const logDetails = currentDay
+          ? currentDay.exercise_blocks
+              .filter((block) => exerciseSelections[block.id] || blockNotes[block.id])
+              .map((block) => {
+                const selection = exerciseSelections[block.id]
+                if (selection) {
+                  return {
+                    section_type: block.block_type,
+                    content: selection.exerciseText,
+                    exercise_id: selection.exerciseId,
+                    tempo_practiced: selection.tempoPracticed,
+                    outcome: selection.outcome,
+                  }
+                }
+                return {
+                  section_type: block.block_type,
+                  content: blockNotes[block.id],
+                }
+              })
+          : []
+
         await api.createLog({
           template_id: template!.id,
           day_number: formData.dayNumber,
           practice_date: formData.date,
           duration_minutes: parseInt(formData.duration),
           notes: formData.notes,
-          log_details: currentDay
-            ? currentDay.exercise_blocks
-                .filter((block) => blockNotes[block.id])
-                .map((block) => ({
-                  section_type: block.block_type,
-                  content: blockNotes[block.id],
-                }))
-            : [],
+          log_details: logDetails,
         })
       }
 
-      alert('Practice log saved!')
+      // Fetch suggestions after logging
+      if (instrument) {
+        try {
+          const progressData = await api.getSuggestionsProgress(instrument.id)
+          const newSuggestions = evaluateRules(
+            progressData.exercises,
+            progressData.progress,
+            dismissedKeys
+          )
+          setSuggestions(newSuggestions)
+        } catch (err) {
+          console.error('Failed to fetch suggestions:', err)
+        }
+      }
+
+      setShowSuccess(true)
       setFormData({
         date: new Date().toISOString().split('T')[0],
         dayNumber: 1,
@@ -127,6 +204,7 @@ export default function LogPracticePage() {
         notes: '',
       })
       setBlockNotes({})
+      setExerciseSelections({})
       setFreeformSections([])
     } catch (err) {
       console.error(err)
@@ -142,6 +220,37 @@ export default function LogPracticePage() {
 
   const removeFreeformSection = (index: number) => {
     setFreeformSections(freeformSections.filter((_, i) => i !== index))
+  }
+
+  const handleAcceptSuggestion = async (suggestion: Suggestion) => {
+    if (!suggestion.action) return
+    try {
+      await api.acceptSuggestion(suggestion.key, suggestion.action)
+      setSuggestions(suggestions.filter((s) => s.key !== suggestion.key))
+      setDismissedKeys(new Set([...dismissedKeys, suggestion.key]))
+    } catch (err) {
+      console.error('Failed to accept suggestion:', err)
+    }
+  }
+
+  const handleDismissSuggestion = async (suggestion: Suggestion) => {
+    try {
+      await api.dismissSuggestion(suggestion.key)
+      setSuggestions(suggestions.filter((s) => s.key !== suggestion.key))
+      setDismissedKeys(new Set([...dismissedKeys, suggestion.key]))
+    } catch (err) {
+      console.error('Failed to dismiss suggestion:', err)
+    }
+  }
+
+  const handleNotYet = (suggestion: Suggestion) => {
+    // Remove from current view but don't dismiss permanently
+    setSuggestions(suggestions.filter((s) => s.key !== suggestion.key))
+  }
+
+  const handleLogAnother = () => {
+    setShowSuccess(false)
+    setSuggestions([])
   }
 
   const updateFreeformSection = (
@@ -170,6 +279,70 @@ export default function LogPracticePage() {
         (a, b) => a.display_order - b.display_order
       )
     : []
+
+  // Success state with suggestions
+  if (showSuccess) {
+    return (
+      <main className="min-h-screen bg-gradient-to-br from-primary-100 to-secondary-100 p-8">
+        <div className="max-w-4xl mx-auto">
+          <div className="bg-white rounded-xl shadow-xl overflow-hidden">
+            <div className="bg-gradient-to-br from-green-500 to-green-700 text-white p-8 text-center">
+              <div className="text-5xl mb-4">&#10003;</div>
+              <h1 className="text-4xl font-bold mb-2">Practice logged!</h1>
+              <p className="text-green-100 text-lg">
+                {formData.duration ? `${formData.duration} minutes recorded` : 'Great work!'}
+              </p>
+            </div>
+
+            <div className="p-8">
+              {suggestions.length > 0 && (
+                <div className="mb-8">
+                  <h2 className="text-lg font-semibold text-gray-700 mb-4">Suggestions</h2>
+                  <div className="space-y-4">
+                    {suggestions.slice(0, 3).map((suggestion) => (
+                      <SuggestionCard
+                        key={suggestion.key}
+                        suggestion={suggestion}
+                        onAccept={() => handleAcceptSuggestion(suggestion)}
+                        onDismiss={() => handleDismissSuggestion(suggestion)}
+                        onNotYet={() => handleNotYet(suggestion)}
+                      />
+                    ))}
+                  </div>
+                  {suggestions.length > 3 && (
+                    <p className="text-sm text-gray-500 mt-4 text-center">
+                      +{suggestions.length - 3} more suggestions on the{' '}
+                      <a
+                        href={`/${instrumentName}/suggestions`}
+                        className="text-primary-600 hover:underline"
+                      >
+                        suggestions page
+                      </a>
+                    </p>
+                  )}
+                </div>
+              )}
+
+              <div className="flex gap-4">
+                <button
+                  onClick={handleLogAnother}
+                  className="flex-1 bg-primary-600 text-white py-3 rounded-lg font-semibold hover:bg-primary-700 transition-colors"
+                >
+                  Log another session
+                </button>
+                <button
+                  onClick={() => router.push(`/${instrumentName}/history`)}
+                  className="flex-1 bg-gray-100 text-gray-700 py-3 rounded-lg font-semibold hover:bg-gray-200 transition-colors"
+                >
+                  View history
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+    )
+  }
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-primary-100 to-secondary-100 p-8">
@@ -276,28 +449,40 @@ export default function LogPracticePage() {
                 </label>
 
                 {block.exercises.length > 0 ? (
-                  <select
-                    value={blockNotes[block.id] || ''}
-                    onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
-                      setBlockNotes({
-                        ...blockNotes,
-                        [block.id]: e.target.value,
-                      })
-                    }
-                    className="w-full px-4 py-3 border-2 border-gray-200 rounded-lg focus:border-primary-500 focus:outline-none"
-                  >
-                    <option value="">Select exercise...</option>
-                    {[...block.exercises]
-                      .sort(
-                        (a: Exercise, b: Exercise) =>
-                          a.display_order - b.display_order
-                      )
-                      .map((ex: Exercise) => (
-                        <option key={ex.id} value={ex.exercise_text}>
-                          {ex.exercise_text}
-                        </option>
-                      ))}
-                  </select>
+                  <div className="space-y-3">
+                    <select
+                      value={exerciseSelections[block.id]?.exerciseId?.toString() || ''}
+                      onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+                        const exerciseId = parseInt(e.target.value)
+                        const exercise = block.exercises.find((ex) => ex.id === exerciseId)
+                        handleExerciseSelect(block.id, exercise || null)
+                      }}
+                      className="w-full px-4 py-3 border-2 border-gray-200 rounded-lg focus:border-primary-500 focus:outline-none"
+                    >
+                      <option value="">Select exercise...</option>
+                      {[...block.exercises]
+                        .sort(
+                          (a: Exercise, b: Exercise) =>
+                            a.display_order - b.display_order
+                        )
+                        .map((ex: Exercise) => (
+                          <option key={ex.id} value={ex.id}>
+                            {ex.exercise_text}
+                            {ex.tempo_bpm && ` (${ex.tempo_bpm} bpm)`}
+                          </option>
+                        ))}
+                    </select>
+                    {exerciseSelections[block.id] && (
+                      <div className="pl-4 border-l-2 border-gray-200">
+                        <p className="text-sm text-gray-600 mb-2">How did it go?</p>
+                        <OutcomeSelector
+                          value={exerciseSelections[block.id]?.outcome}
+                          onChange={(outcome) => handleOutcomeChange(block.id, outcome)}
+                          size="sm"
+                        />
+                      </div>
+                    )}
+                  </div>
                 ) : (
                   <textarea
                     value={blockNotes[block.id] || ''}

--- a/frontend/src/app/[instrument]/plan/page.tsx
+++ b/frontend/src/app/[instrument]/plan/page.tsx
@@ -2,8 +2,10 @@
 
 import { useEffect, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
+import Link from 'next/link'
 import { useApi } from '@/lib/useApi'
-import type { Instrument, PracticeTemplate, PracticeDay, BlockType } from '@/lib/types'
+import { evaluateRules } from '@/lib/progressionRules'
+import type { Instrument, PracticeTemplate, PracticeDay, BlockType, Suggestion } from '@/lib/types'
 import DaySelector from '@/components/DaySelector'
 import PracticeBlock from '@/components/PracticeBlock'
 
@@ -12,25 +14,43 @@ export default function PracticePlanPage() {
   const router = useRouter()
   const api = useApi()
   const instrumentName = params.instrument as string
+  const [instrument, setInstrument] = useState<Instrument | null>(null)
   const [template, setTemplate] = useState<PracticeTemplate | null>(null)
   const [selectedDay, setSelectedDay] = useState(1)
   const [currentDayData, setCurrentDayData] = useState<PracticeDay | null>(null)
   const [blockTypes, setBlockTypes] = useState<BlockType[]>([])
+  const [suggestionsCount, setSuggestionsCount] = useState(0)
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     api.getBlockTypes().then(setBlockTypes).catch(() => {})
 
     Promise.all([api.getInstruments(), api.getTemplates()])
-      .then(([instruments, allTemplates]) => {
+      .then(async ([instruments, allTemplates]) => {
         const inst = instruments.find(
           (i) => i.name.toLowerCase() === instrumentName.toLowerCase()
         )
         if (inst) {
+          setInstrument(inst)
           const tmpl = allTemplates.find(
             (t) => t.instrument_id === inst.id && t.is_active
           )
           if (tmpl) {
+            // Fetch suggestions count
+            try {
+              const progressData = await api.getSuggestionsProgress(inst.id)
+              const dismissedKeys: Set<string> = typeof window !== 'undefined'
+                ? new Set(JSON.parse(localStorage.getItem(`dismissed_suggestions_${instrumentName}`) || '[]') as string[])
+                : new Set<string>()
+              const suggestions = evaluateRules(
+                progressData.exercises,
+                progressData.progress,
+                dismissedKeys
+              )
+              setSuggestionsCount(suggestions.length)
+            } catch (err) {
+              console.error('Failed to load suggestions:', err)
+            }
             return api.getTemplate(tmpl.id)
           }
         }
@@ -88,16 +108,29 @@ export default function PracticePlanPage() {
       <div className="max-w-6xl mx-auto">
         <div className="bg-white rounded-xl shadow-xl overflow-hidden">
           <div className="bg-gradient-to-br from-primary-500 to-primary-700 text-white p-8 text-center relative">
-            <h1 className="text-4xl font-bold mb-2">📅 Practice Plan</h1>
+            <h1 className="text-4xl font-bold mb-2">Practice Plan</h1>
             <p className="text-primary-100 text-lg">{template.name}</p>
-            <button
-              onClick={() =>
-                router.push(`/${instrumentName}/template/edit?templateId=${template.id}`)
-              }
-              className="mt-3 inline-block text-sm text-primary-200 hover:text-white underline underline-offset-2"
-            >
-              Edit Template
-            </button>
+            <div className="mt-3 flex items-center justify-center gap-4">
+              <button
+                onClick={() =>
+                  router.push(`/${instrumentName}/template/edit?templateId=${template.id}`)
+                }
+                className="text-sm text-primary-200 hover:text-white underline underline-offset-2"
+              >
+                Edit Template
+              </button>
+              {suggestionsCount > 0 && (
+                <Link
+                  href={`/${instrumentName}/suggestions`}
+                  className="inline-flex items-center gap-2 bg-white/20 hover:bg-white/30 px-3 py-1 rounded-full text-sm transition-colors"
+                >
+                  <span className="bg-yellow-400 text-yellow-900 text-xs font-bold px-2 py-0.5 rounded-full">
+                    {suggestionsCount}
+                  </span>
+                  <span>Suggestions</span>
+                </Link>
+              )}
+            </div>
           </div>
 
           <div className="p-8">

--- a/frontend/src/app/[instrument]/suggestions/page.tsx
+++ b/frontend/src/app/[instrument]/suggestions/page.tsx
@@ -1,0 +1,180 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { useApi } from '@/lib/useApi'
+import SuggestionCard from '@/components/SuggestionCard'
+import { evaluateRules } from '@/lib/progressionRules'
+import type { Instrument, Suggestion } from '@/lib/types'
+
+export default function SuggestionsPage() {
+  const params = useParams()
+  const router = useRouter()
+  const api = useApi()
+  const instrumentName = params.instrument as string
+
+  const [instrument, setInstrument] = useState<Instrument | null>(null)
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([])
+  const [loading, setLoading] = useState(true)
+  const [dismissedKeys, setDismissedKeys] = useState<Set<string>>(() => {
+    // Load dismissed keys from localStorage
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem(`dismissed_suggestions_${instrumentName}`)
+      return stored ? new Set(JSON.parse(stored)) : new Set()
+    }
+    return new Set()
+  })
+
+  useEffect(() => {
+    const loadSuggestions = async () => {
+      try {
+        const instruments = await api.getInstruments()
+        const inst = instruments.find(
+          (i) => i.name.toLowerCase() === instrumentName.toLowerCase()
+        )
+
+        if (!inst) {
+          router.push('/')
+          return
+        }
+
+        setInstrument(inst)
+
+        const progressData = await api.getSuggestionsProgress(inst.id)
+        const newSuggestions = evaluateRules(
+          progressData.exercises,
+          progressData.progress,
+          dismissedKeys
+        )
+        setSuggestions(newSuggestions)
+      } catch (err) {
+        console.error('Failed to load suggestions:', err)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    loadSuggestions()
+  }, [instrumentName, api, router, dismissedKeys])
+
+  const saveDismissedKeys = (keys: Set<string>) => {
+    setDismissedKeys(keys)
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(
+        `dismissed_suggestions_${instrumentName}`,
+        JSON.stringify([...keys])
+      )
+    }
+  }
+
+  const handleAcceptSuggestion = async (suggestion: Suggestion) => {
+    if (!suggestion.action) return
+    try {
+      await api.acceptSuggestion(suggestion.key, suggestion.action)
+      setSuggestions(suggestions.filter((s) => s.key !== suggestion.key))
+      const newKeys = new Set([...dismissedKeys, suggestion.key])
+      saveDismissedKeys(newKeys)
+    } catch (err) {
+      console.error('Failed to accept suggestion:', err)
+    }
+  }
+
+  const handleDismissSuggestion = async (suggestion: Suggestion) => {
+    try {
+      await api.dismissSuggestion(suggestion.key)
+      setSuggestions(suggestions.filter((s) => s.key !== suggestion.key))
+      const newKeys = new Set([...dismissedKeys, suggestion.key])
+      saveDismissedKeys(newKeys)
+    } catch (err) {
+      console.error('Failed to dismiss suggestion:', err)
+    }
+  }
+
+  if (loading) {
+    return (
+      <main className="min-h-screen bg-gradient-to-br from-primary-100 to-secondary-100 p-8">
+        <div className="max-w-4xl mx-auto">
+          <p className="text-center text-gray-600">Loading suggestions...</p>
+        </div>
+      </main>
+    )
+  }
+
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-primary-100 to-secondary-100 p-8">
+      <div className="max-w-4xl mx-auto">
+        <div className="bg-white rounded-xl shadow-xl overflow-hidden">
+          <div className="bg-gradient-to-br from-purple-500 to-purple-700 text-white p-8 text-center">
+            <h1 className="text-4xl font-bold mb-2">Suggestions</h1>
+            <p className="text-purple-100 text-lg">
+              {instrument?.name} practice recommendations
+            </p>
+          </div>
+
+          <div className="p-8">
+            {suggestions.length === 0 ? (
+              <div className="text-center py-12">
+                <div className="text-6xl mb-4">&#127942;</div>
+                <h2 className="text-xl font-semibold text-gray-700 mb-2">
+                  No suggestions right now
+                </h2>
+                <p className="text-gray-500 mb-6">
+                  Keep practicing! Suggestions appear based on your progress and
+                  practice history.
+                </p>
+                <Link
+                  href={`/${instrumentName}/log`}
+                  className="inline-block bg-primary-600 text-white px-6 py-3 rounded-lg font-semibold hover:bg-primary-700 transition-colors"
+                >
+                  Log a practice session
+                </Link>
+              </div>
+            ) : (
+              <div className="space-y-4">
+                {suggestions.map((suggestion) => (
+                  <SuggestionCard
+                    key={suggestion.key}
+                    suggestion={suggestion}
+                    onAccept={
+                      suggestion.action
+                        ? () => handleAcceptSuggestion(suggestion)
+                        : undefined
+                    }
+                    onDismiss={() => handleDismissSuggestion(suggestion)}
+                    compact
+                  />
+                ))}
+              </div>
+            )}
+
+            <div className="mt-8 pt-8 border-t border-gray-200">
+              <div className="flex gap-4 justify-center">
+                <Link
+                  href={`/${instrumentName}/plan`}
+                  className="text-primary-600 hover:text-primary-800 font-medium"
+                >
+                  View practice plan
+                </Link>
+                <span className="text-gray-300">|</span>
+                <Link
+                  href={`/${instrumentName}/log`}
+                  className="text-primary-600 hover:text-primary-800 font-medium"
+                >
+                  Log practice
+                </Link>
+                <span className="text-gray-300">|</span>
+                <Link
+                  href={`/${instrumentName}/history`}
+                  className="text-primary-600 hover:text-primary-800 font-medium"
+                >
+                  View history
+                </Link>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/frontend/src/components/OutcomeSelector.tsx
+++ b/frontend/src/components/OutcomeSelector.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import type { PracticeOutcome } from '@/lib/types'
+
+interface OutcomeSelectorProps {
+  value?: PracticeOutcome
+  onChange: (outcome: PracticeOutcome | undefined) => void
+  size?: 'sm' | 'md'
+}
+
+const outcomes: { value: PracticeOutcome; label: string; emoji: string; color: string }[] = [
+  {
+    value: 'struggled',
+    label: 'Struggled',
+    emoji: '😓',
+    color: 'bg-red-100 text-red-700 border-red-300 hover:bg-red-200',
+  },
+  {
+    value: 'okay',
+    label: 'Okay',
+    emoji: '😐',
+    color: 'bg-yellow-100 text-yellow-700 border-yellow-300 hover:bg-yellow-200',
+  },
+  {
+    value: 'nailed_it',
+    label: 'Nailed it!',
+    emoji: '🎯',
+    color: 'bg-green-100 text-green-700 border-green-300 hover:bg-green-200',
+  },
+]
+
+export default function OutcomeSelector({ value, onChange, size = 'md' }: OutcomeSelectorProps) {
+  const sizeClasses = size === 'sm' ? 'px-2 py-1 text-sm' : 'px-3 py-2'
+
+  return (
+    <div className="flex gap-2">
+      {outcomes.map((outcome) => {
+        const isSelected = value === outcome.value
+        return (
+          <button
+            key={outcome.value}
+            type="button"
+            onClick={() => onChange(isSelected ? undefined : outcome.value)}
+            className={`
+              ${sizeClasses}
+              rounded-lg border-2 font-medium transition-all
+              ${isSelected
+                ? `${outcome.color} ring-2 ring-offset-1 ring-current`
+                : 'bg-gray-50 text-gray-600 border-gray-200 hover:bg-gray-100'
+              }
+            `}
+          >
+            <span className="mr-1">{outcome.emoji}</span>
+            {outcome.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/components/SuggestionCard.tsx
+++ b/frontend/src/components/SuggestionCard.tsx
@@ -1,0 +1,140 @@
+'use client'
+
+import type { Suggestion } from '@/lib/types'
+
+interface SuggestionCardProps {
+  suggestion: Suggestion
+  onAccept?: () => void
+  onDismiss?: () => void
+  onNotYet?: () => void
+  showExerciseName?: boolean
+  compact?: boolean
+}
+
+const typeStyles: Record<string, { icon: string; bgColor: string; borderColor: string }> = {
+  tempo_increase: {
+    icon: '🚀',
+    bgColor: 'bg-blue-50',
+    borderColor: 'border-blue-200',
+  },
+  tempo_decrease: {
+    icon: '🐢',
+    bgColor: 'bg-amber-50',
+    borderColor: 'border-amber-200',
+  },
+  revisit: {
+    icon: '🔄',
+    bgColor: 'bg-purple-50',
+    borderColor: 'border-purple-200',
+  },
+  advance: {
+    icon: '⭐',
+    bgColor: 'bg-green-50',
+    borderColor: 'border-green-200',
+  },
+  new_variation: {
+    icon: '💪',
+    bgColor: 'bg-indigo-50',
+    borderColor: 'border-indigo-200',
+  },
+  new_key: {
+    icon: '🎵',
+    bgColor: 'bg-pink-50',
+    borderColor: 'border-pink-200',
+  },
+}
+
+export default function SuggestionCard({
+  suggestion,
+  onAccept,
+  onDismiss,
+  onNotYet,
+  showExerciseName = true,
+  compact = false,
+}: SuggestionCardProps) {
+  const style = typeStyles[suggestion.type] || typeStyles.new_variation
+
+  if (compact) {
+    return (
+      <div
+        className={`${style.bgColor} ${style.borderColor} border rounded-lg p-3`}
+      >
+        <div className="flex items-start gap-2">
+          <span className="text-lg">{style.icon}</span>
+          <div className="flex-1 min-w-0">
+            {showExerciseName && (
+              <p className="text-sm font-medium text-gray-700 truncate">
+                {suggestion.exercise_text}
+              </p>
+            )}
+            <p className="text-sm text-gray-600">{suggestion.message}</p>
+          </div>
+        </div>
+        <div className="flex gap-2 mt-2 ml-7">
+          {suggestion.action && onAccept && (
+            <button
+              onClick={onAccept}
+              className="text-xs px-2 py-1 bg-white border border-gray-300 rounded hover:bg-gray-50 font-medium"
+            >
+              Accept
+            </button>
+          )}
+          {onDismiss && (
+            <button
+              onClick={onDismiss}
+              className="text-xs px-2 py-1 text-gray-500 hover:text-gray-700"
+            >
+              Dismiss
+            </button>
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className={`${style.bgColor} ${style.borderColor} border-2 rounded-xl p-4`}
+    >
+      <div className="flex items-start gap-3">
+        <span className="text-2xl">{style.icon}</span>
+        <div className="flex-1">
+          <p className="text-sm font-medium text-gray-500 mb-1">Suggestion</p>
+          {showExerciseName && (
+            <p className="font-semibold text-gray-800 mb-2">
+              {suggestion.exercise_text}
+            </p>
+          )}
+          <p className="text-gray-700">{suggestion.message}</p>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-2 mt-4 ml-11">
+        {suggestion.action && onAccept && (
+          <button
+            onClick={onAccept}
+            className="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 font-medium text-sm transition-colors"
+          >
+            Update exercise
+          </button>
+        )}
+        {onNotYet && (
+          <button
+            onClick={onNotYet}
+            className="px-4 py-2 bg-white border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 font-medium text-sm transition-colors"
+          >
+            Not yet
+          </button>
+        )}
+        {onDismiss && (
+          <button
+            onClick={onDismiss}
+            className="px-4 py-2 text-gray-500 hover:text-gray-700 font-medium text-sm transition-colors"
+          >
+            Dismiss
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -16,6 +16,8 @@ import type {
   ExerciseUpdate,
   ExerciseBlock,
   Exercise,
+  SuggestionsProgressResponse,
+  SuggestionAction,
 } from './types'
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
@@ -186,6 +188,27 @@ export function createAuthenticatedAPI(getToken: () => Promise<string | null>) {
     getAnalytics: (templateId?: number) =>
       authFetchAPI<AnalyticsSummary>(
         `/api/analytics/${templateId ? `?template_id=${templateId}` : ''}`
+      ),
+
+    // Suggestions
+    getSuggestionsProgress: (instrumentId?: number) =>
+      authFetchAPI<SuggestionsProgressResponse>(
+        `/api/suggestions/progress${instrumentId ? `?instrument_id=${instrumentId}` : ''}`
+      ),
+
+    dismissSuggestion: (suggestionKey: string) =>
+      authFetchAPI<{ status: string; suggestion_key: string }>(
+        `/api/suggestions/dismiss/${suggestionKey}`,
+        { method: 'POST' }
+      ),
+
+    acceptSuggestion: (suggestionKey: string, action: SuggestionAction) =>
+      authFetchAPI<{ status: string; suggestion_key: string; exercise: Exercise }>(
+        `/api/suggestions/accept/${suggestionKey}`,
+        {
+          method: 'POST',
+          body: JSON.stringify(action),
+        }
       ),
   }
 }

--- a/frontend/src/lib/metronome.ts
+++ b/frontend/src/lib/metronome.ts
@@ -1,0 +1,77 @@
+/**
+ * Metronome utilities for tempo calculations
+ *
+ * Standard metronome markings (Maelzel markings) used for snapping tempo values
+ * to musically meaningful increments.
+ */
+
+// Standard metronome markings
+export const METRONOME_MARKINGS: readonly number[] = [
+  40, 42, 44, 46, 48, 50, 52, 54, 56, 58, 60,
+  63, 66, 69, 72, 76, 80, 84, 88, 92, 96,
+  100, 104, 108, 112, 116, 120, 126, 132, 138, 144,
+  152, 160, 168, 176, 184, 192, 200, 208
+]
+
+/**
+ * Calculate the next tempo based on a percentage increase, snapping to standard markings.
+ *
+ * @param current - Current tempo in BPM
+ * @param increasePercent - Percentage increase (default 10%)
+ * @returns Next standard metronome marking at or above the target
+ *
+ * @example
+ * nextTempo(60)   // → 66  (10% of 60 = 66)
+ * nextTempo(100)  // → 112 (10% of 100 = 110, snaps up to 112)
+ */
+export function nextTempo(current: number, increasePercent = 10): number {
+  const target = current * (1 + increasePercent / 100)
+  return METRONOME_MARKINGS.find((m) => m >= target) ?? Math.round(target)
+}
+
+/**
+ * Calculate the previous tempo based on a percentage decrease, snapping to standard markings.
+ *
+ * @param current - Current tempo in BPM
+ * @param decreasePercent - Percentage decrease (default 10%)
+ * @returns Previous standard metronome marking at or below the target
+ *
+ * @example
+ * prevTempo(72)  // → 66  (10% of 72 = 64.8, snaps down to 66... wait, that's wrong)
+ * prevTempo(72)  // → 66  (10% less = 64.8, find largest marking <= 64.8 = 63)
+ */
+export function prevTempo(current: number, decreasePercent = 10): number {
+  const target = current * (1 - decreasePercent / 100)
+  return [...METRONOME_MARKINGS].reverse().find((m) => m <= target) ?? Math.round(target)
+}
+
+/**
+ * Find the closest standard metronome marking to a given tempo.
+ *
+ * @param tempo - Tempo to snap
+ * @returns Closest standard metronome marking
+ */
+export function snapToMarking(tempo: number): number {
+  let closest = METRONOME_MARKINGS[0]
+  let minDiff = Math.abs(tempo - closest)
+
+  for (const marking of METRONOME_MARKINGS) {
+    const diff = Math.abs(tempo - marking)
+    if (diff < minDiff) {
+      minDiff = diff
+      closest = marking
+    }
+  }
+
+  return closest
+}
+
+/**
+ * Format a tempo value for display.
+ *
+ * @param tempo - Tempo in BPM
+ * @returns Formatted string like "♩=72"
+ */
+export function formatTempo(tempo: number): string {
+  return `♩=${tempo}`
+}

--- a/frontend/src/lib/progressionRules.ts
+++ b/frontend/src/lib/progressionRules.ts
@@ -1,0 +1,213 @@
+/**
+ * Progression Rules Engine
+ *
+ * Evaluates exercise progress data and generates suggestions for practice improvements.
+ * This is the "basic AI" - useful now, and the foundation for richer AI coaching later.
+ */
+
+import type { Exercise, ExerciseProgress, Suggestion, SuggestionType } from './types'
+import { nextTempo, prevTempo, formatTempo } from './metronome'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface ProgressionRule {
+  id: string
+  name: string
+  description: string
+  condition: (progress: ExerciseProgress, exercise: Exercise) => boolean
+  suggestion: (progress: ExerciseProgress, exercise: Exercise) => Omit<Suggestion, 'key' | 'exercise_id' | 'exercise_text'>
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Calculate days since a given date.
+ */
+function daysSince(dateString?: string): number {
+  if (!dateString) return Infinity
+  const date = new Date(dateString)
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  return Math.floor(diffMs / (1000 * 60 * 60 * 24))
+}
+
+// ---------------------------------------------------------------------------
+// Rules
+// ---------------------------------------------------------------------------
+
+const rules: ProgressionRule[] = [
+  // Rule 1: Increase tempo when consistently nailing it
+  {
+    id: 'tempo_increase',
+    name: 'Increase tempo',
+    description: 'Suggest faster tempo after consistent success',
+    condition: (progress, exercise) =>
+      progress.times_practiced >= 4 &&
+      progress.nailed_it_count >= 2 &&
+      progress.current_tempo != null &&
+      progress.current_tempo < 180 &&
+      exercise.tempo_bpm != null,
+    suggestion: (progress, exercise) => {
+      const currentTempo = progress.current_tempo ?? exercise.tempo_bpm!
+      const newTempo = nextTempo(currentTempo)
+      return {
+        type: 'tempo_increase' as SuggestionType,
+        message: `You've practiced this ${progress.times_practiced} times at ${formatTempo(currentTempo)}. Ready to try ${formatTempo(newTempo)}?`,
+        action: {
+          exercise_id: 0, // Will be filled in by evaluator
+          field: 'tempo_bpm',
+          value: newTempo,
+        },
+      }
+    },
+  },
+
+  // Rule 2: Slow down when struggling
+  {
+    id: 'tempo_decrease',
+    name: 'Reduce tempo',
+    description: 'Suggest slower tempo when struggling',
+    condition: (progress, exercise) =>
+      progress.struggled_count >= 3 &&
+      progress.struggled_count > progress.nailed_it_count &&
+      progress.current_tempo != null &&
+      progress.current_tempo > 40 &&
+      exercise.tempo_bpm != null,
+    suggestion: (progress, exercise) => {
+      const currentTempo = progress.current_tempo ?? exercise.tempo_bpm!
+      const newTempo = prevTempo(currentTempo)
+      return {
+        type: 'tempo_decrease' as SuggestionType,
+        message: `This seems challenging at ${formatTempo(currentTempo)}. Try slowing down to ${formatTempo(newTempo)}?`,
+        action: {
+          exercise_id: 0,
+          field: 'tempo_bpm',
+          value: newTempo,
+        },
+      }
+    },
+  },
+
+  // Rule 3: Revisit neglected exercises
+  {
+    id: 'revisit_stale',
+    name: 'Revisit neglected exercise',
+    description: 'Suggest returning to exercises not practiced recently',
+    condition: (progress) =>
+      daysSince(progress.last_practiced_at) > 14 &&
+      progress.times_practiced > 0,
+    suggestion: (progress) => {
+      const days = daysSince(progress.last_practiced_at)
+      return {
+        type: 'revisit' as SuggestionType,
+        message: `You haven't practiced this in ${days} days. Want to add it back to your rotation?`,
+      }
+    },
+  },
+
+  // Rule 4: Celebrate and encourage advancement after mastery
+  {
+    id: 'advance_mastery',
+    name: 'Ready to advance',
+    description: 'Suggest moving on after demonstrating mastery',
+    condition: (progress) =>
+      progress.times_practiced >= 10 &&
+      progress.nailed_it_count >= 7 &&
+      progress.struggled_count <= 1,
+    suggestion: () => ({
+      type: 'advance' as SuggestionType,
+      message: `You've mastered this exercise! Consider adding a more challenging variation or moving on.`,
+    }),
+  },
+
+  // Rule 5: Encourage consistency for exercises with mixed results
+  {
+    id: 'build_consistency',
+    name: 'Build consistency',
+    description: 'Encourage more practice when results are mixed',
+    condition: (progress) =>
+      progress.times_practiced >= 5 &&
+      progress.okay_count > progress.nailed_it_count &&
+      progress.okay_count > progress.struggled_count,
+    suggestion: (progress, exercise) => {
+      const currentTempo = progress.current_tempo ?? exercise.tempo_bpm
+      const tempoNote = currentTempo ? ` at ${formatTempo(currentTempo)}` : ''
+      return {
+        type: 'new_variation' as SuggestionType,
+        message: `You're doing okay${tempoNote}, but not quite consistent yet. Keep practicing to build muscle memory!`,
+      }
+    },
+  },
+]
+
+// ---------------------------------------------------------------------------
+// Evaluation
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate all rules against exercise progress data and generate suggestions.
+ *
+ * @param exercises - List of exercises with metadata
+ * @param progressRecords - Progress records keyed by exercise_id
+ * @param dismissedKeys - Set of suggestion keys that have been dismissed
+ * @returns Array of suggestions that match current conditions
+ */
+export function evaluateRules(
+  exercises: Exercise[],
+  progressRecords: ExerciseProgress[],
+  dismissedKeys: Set<string> = new Set()
+): Suggestion[] {
+  const suggestions: Suggestion[] = []
+
+  // Create a map of exercise_id -> progress for quick lookup
+  const progressMap = new Map<number, ExerciseProgress>()
+  for (const p of progressRecords) {
+    progressMap.set(p.exercise_id, p)
+  }
+
+  for (const exercise of exercises) {
+    const progress = progressMap.get(exercise.id)
+    if (!progress) continue // No progress data yet
+
+    for (const rule of rules) {
+      const suggestionKey = `exercise_${exercise.id}_${rule.id}`
+
+      // Skip if already dismissed
+      if (dismissedKeys.has(suggestionKey)) continue
+
+      // Check if rule condition is met
+      if (rule.condition(progress, exercise)) {
+        const baseSuggestion = rule.suggestion(progress, exercise)
+
+        // Fill in exercise details
+        const suggestion: Suggestion = {
+          key: suggestionKey,
+          exercise_id: exercise.id,
+          exercise_text: exercise.exercise_text,
+          ...baseSuggestion,
+        }
+
+        // Fill in action exercise_id if present
+        if (suggestion.action) {
+          suggestion.action.exercise_id = exercise.id
+        }
+
+        suggestions.push(suggestion)
+        break // Only one suggestion per exercise
+      }
+    }
+  }
+
+  return suggestions
+}
+
+/**
+ * Get the list of available rules (for debugging/admin purposes).
+ */
+export function getRules(): Pick<ProgressionRule, 'id' | 'name' | 'description'>[] {
+  return rules.map(({ id, name, description }) => ({ id, name, description }))
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,3 +1,18 @@
+// Enums (matching backend)
+export type TechniqueCategory =
+  | 'scales'
+  | 'arpeggios'
+  | 'etude'
+  | 'long_tones'
+  | 'shifting'
+  | 'bowing'
+  | 'articulation'
+  | 'repertoire'
+  | 'sight_reading'
+  | 'other'
+
+export type PracticeOutcome = 'struggled' | 'okay' | 'nailed_it'
+
 export interface BlockType {
   id: number
   slug: string
@@ -21,6 +36,11 @@ export interface Exercise {
   id: number
   exercise_text: string
   display_order: number
+  tempo_bpm?: number
+  key?: string
+  technique_category?: TechniqueCategory
+  difficulty_level?: number
+  notes?: string
 }
 
 export interface ExerciseBlock {
@@ -57,6 +77,10 @@ export interface PracticeTemplate {
 export interface PracticeLogDetail {
   section_type: string
   content?: string
+  exercise_id?: number
+  tempo_practiced?: number
+  outcome?: PracticeOutcome
+  notes?: string
 }
 
 export interface PracticeLogCreate {
@@ -118,11 +142,62 @@ export interface BlockReorder {
 export interface ExerciseCreate {
   exercise_text: string
   display_order?: number
+  tempo_bpm?: number
+  key?: string
+  technique_category?: TechniqueCategory
+  difficulty_level?: number
+  notes?: string
 }
 
 export interface ExerciseUpdate {
   exercise_text?: string
   display_order?: number
+  tempo_bpm?: number
+  key?: string
+  technique_category?: TechniqueCategory
+  difficulty_level?: number
+  notes?: string
 }
 
+// Exercise progress tracking
+export interface ExerciseProgress {
+  id: number
+  exercise_id: number
+  times_practiced: number
+  last_practiced_at?: string
+  current_tempo?: number
+  current_difficulty?: number
+  struggled_count: number
+  okay_count: number
+  nailed_it_count: number
+}
 
+// Suggestions API response
+export interface SuggestionsProgressResponse {
+  exercises: Exercise[]
+  progress: ExerciseProgress[]
+}
+
+// Suggestion types for rules engine
+export type SuggestionType =
+  | 'tempo_increase'
+  | 'tempo_decrease'
+  | 'new_variation'
+  | 'new_key'
+  | 'revisit'
+  | 'advance'
+
+export interface SuggestionAction {
+  exercise_id: number
+  field: 'tempo_bpm' | 'key' | 'technique_category' | 'difficulty_level' | 'notes'
+  value: number | string
+}
+
+export interface Suggestion {
+  key: string
+  exercise_id: number
+  exercise_text: string
+  type: SuggestionType
+  message: string
+  action?: SuggestionAction
+}

--- a/frontend/src/lib/useApi.ts
+++ b/frontend/src/lib/useApi.ts
@@ -1,0 +1,20 @@
+'use client'
+
+import { useAuth } from '@clerk/nextjs'
+import { createAuthenticatedAPI } from './api'
+import { useMemo } from 'react'
+
+/**
+ * Custom hook to get an authenticated API client
+ * Uses Clerk's useAuth to automatically include JWT tokens in requests
+ */
+export function useApi() {
+  const { getToken } = useAuth()
+  
+  const api = useMemo(() => {
+    return createAuthenticatedAPI(getToken)
+  }, [getToken])
+  
+  return api
+}
+


### PR DESCRIPTION
Frontend implementation for practice suggestions:
- Add metronome.ts with tempo utilities (nextTempo, prevTempo, snapToMarking)
- Add progressionRules.ts with 5 initial rules:
  - Tempo increase after consistent success
  - Tempo decrease when struggling
  - Revisit neglected exercises (14+ days)
  - Advance after mastery
  - Build consistency encouragement
- Add OutcomeSelector component for logging practice outcomes
- Add SuggestionCard component for displaying suggestions
- Update log page with outcome tracking and post-log suggestions
- Add suggestions page at /{instrument}/suggestions
- Add suggestions indicator badge on plan page
- Update types.ts with TechniqueCategory, PracticeOutcome, ExerciseProgress
- Add suggestions API methods to api.ts