### PR TITLE
Fix user email/name not being saved from Clerk JWT

### DIFF
--- a/backend/alembic/versions/1bb48989475d_split_user_name_into_first_last.py
+++ b/backend/alembic/versions/1bb48989475d_split_user_name_into_first_last.py
@@ -1,0 +1,64 @@
+"""split_user_name_into_first_last
+
+Revision ID: 1bb48989475d
+Revises: d4e5f6g7h8i9
+Create Date: 2026-01-30 11:52:52.428488
+
+"""
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+
+
+# revision identifiers, used by Alembic.
+revision = '1bb48989475d'
+down_revision = 'd4e5f6g7h8i9'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add new first_name and last_name columns
+    op.add_column('users', sa.Column('first_name', sqlmodel.sql.sqltypes.AutoString(length=255), nullable=True))
+    op.add_column('users', sa.Column('last_name', sqlmodel.sql.sqltypes.AutoString(length=255), nullable=True))
+
+    # Migrate data: split name on first space
+    # first_name gets everything before the first space, last_name gets everything after
+    op.execute("""
+        UPDATE users
+        SET first_name = CASE
+                WHEN name IS NULL THEN NULL
+                WHEN position(' ' in name) > 0 THEN substring(name from 1 for position(' ' in name) - 1)
+                ELSE name
+            END,
+            last_name = CASE
+                WHEN name IS NULL THEN NULL
+                WHEN position(' ' in name) > 0 THEN substring(name from position(' ' in name) + 1)
+                ELSE NULL
+            END
+    """)
+
+    # Drop the old name column
+    op.drop_column('users', 'name')
+
+
+def downgrade() -> None:
+    # Add back the name column
+    op.add_column('users', sa.Column('name', sqlmodel.sql.sqltypes.AutoString(length=255), nullable=True))
+
+    # Migrate data: combine first_name and last_name back into name
+    op.execute("""
+        UPDATE users
+        SET name = CASE
+                WHEN first_name IS NULL AND last_name IS NULL THEN NULL
+                WHEN first_name IS NULL THEN last_name
+                WHEN last_name IS NULL THEN first_name
+                ELSE first_name || ' ' || last_name
+            END
+    """)
+
+    # Drop the new columns
+    op.drop_column('users', 'last_name')
+    op.drop_column('users', 'first_name')
+
+

--- a/backend/app/api/user.py
+++ b/backend/app/api/user.py
@@ -38,7 +38,8 @@ async def get_current_user_info(
             "id": current_user.id,
             "clerk_user_id": current_user.clerk_user_id,
             "email": current_user.email,
-            "name": current_user.name,
+            "first_name": current_user.first_name,
+            "last_name": current_user.last_name,
             "created_at": current_user.created_at.isoformat()
         }
     }

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -62,7 +62,13 @@ async def verify_clerk_token(authorization: Optional[str] = Header(None)) -> Opt
         )
 
 
-async def get_or_create_user(session: AsyncSession, clerk_user_id: str, email: str, name: Optional[str] = None) -> User:
+async def get_or_create_user(
+    session: AsyncSession,
+    clerk_user_id: str,
+    email: str,
+    first_name: Optional[str] = None,
+    last_name: Optional[str] = None
+) -> User:
     """
     Get existing user or create new user record from Clerk JWT claims.
     Called on first authenticated request for each user.
@@ -74,11 +80,13 @@ async def get_or_create_user(session: AsyncSession, clerk_user_id: str, email: s
     user = result.first()
 
     if user:
-        # Update email/name if we have new values to set
+        # Update fields if we have new values to set
         needs_update = False
         if email and user.email != email:
             needs_update = True
-        if name and user.name != name:
+        if first_name and user.first_name != first_name:
+            needs_update = True
+        if last_name and user.last_name != last_name:
             needs_update = True
 
         if needs_update:
@@ -87,7 +95,8 @@ async def get_or_create_user(session: AsyncSession, clerk_user_id: str, email: s
                 .where(User.clerk_user_id == clerk_user_id)
                 .values(
                     email=email if email else user.email,
-                    name=name if name else user.name
+                    first_name=first_name if first_name else user.first_name,
+                    last_name=last_name if last_name else user.last_name
                 )
             )
             await session.exec(stmt)
@@ -99,7 +108,8 @@ async def get_or_create_user(session: AsyncSession, clerk_user_id: str, email: s
     user = User(
         clerk_user_id=clerk_user_id,
         email=email,
-        name=name
+        first_name=first_name,
+        last_name=last_name
     )
     session.add(user)
     await session.commit()
@@ -123,16 +133,12 @@ async def get_current_user_optional(authorization: Optional[str] = Header(None))
         return None
 
     email = token_payload.get("email", "")
-
-    # Build name from first_name and last_name claims
-    first_name = token_payload.get("first_name", "")
-    last_name = token_payload.get("last_name", "")
-    name_parts = [p for p in [first_name, last_name] if p]
-    name = " ".join(name_parts) if name_parts else None
+    first_name = token_payload.get("first_name") or None
+    last_name = token_payload.get("last_name") or None
 
     # Get or create user in our database
     async with async_session() as session:
-        user = await get_or_create_user(session, clerk_user_id, email, name)
+        user = await get_or_create_user(session, clerk_user_id, email, first_name, last_name)
         return user
 
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -36,15 +36,16 @@ class PracticeOutcome(str, Enum):
 class User(SQLModel, table=True):
     """User account (authenticated via Clerk)"""
     __tablename__ = "users"  # type: ignore[assignment]
-    
+
     id: Optional[int] = Field(default=None, primary_key=True)
     clerk_user_id: str = Field(unique=True, index=True, max_length=255)
     email: str = Field(max_length=255)
-    name: Optional[str] = Field(default=None, max_length=255)
+    first_name: Optional[str] = Field(default=None, max_length=255)
+    last_name: Optional[str] = Field(default=None, max_length=255)
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: Optional[datetime] = Field(default=None, sa_column_kwargs={"onupdate": datetime.utcnow})
     deleted_at: Optional[datetime] = Field(default=None)
-    
+
     # Relationships
     instruments: List["Instrument"] = Relationship(back_populates="user")
     practice_templates: List["PracticeTemplate"] = Relationship(back_populates="user")


### PR DESCRIPTION
Read email, first_name, and last_name from JWT claims instead of relying on claims that weren't present in Clerk's default token. Also use explicit SQL UPDATE for more reliable user record updates.