### PR TITLE
Fix instrument button double-click creating duplicates

### DIFF
--- a/backend/alembic/versions/86c0e14547e8_add_unique_constraint_user_instrument_.py
+++ b/backend/alembic/versions/86c0e14547e8_add_unique_constraint_user_instrument_.py
@@ -1,0 +1,47 @@
+"""add_unique_constraint_user_instrument_name
+
+Revision ID: 86c0e14547e8
+Revises: 1bb48989475d
+Create Date: 2026-01-30 12:09:12.787002
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '86c0e14547e8'
+down_revision = '1bb48989475d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # First, remove duplicate user instruments (keep the oldest one by id)
+    # This handles any existing duplicates before adding the constraint
+    op.execute("""
+        DELETE FROM instruments
+        WHERE id NOT IN (
+            SELECT MIN(id)
+            FROM instruments
+            WHERE user_id IS NOT NULL
+            GROUP BY user_id, name
+        )
+        AND user_id IS NOT NULL
+    """)
+
+    # Add unique constraint on (user_id, name) for instruments
+    # This prevents a user from having duplicate instrument names
+    # Note: PostgreSQL treats NULLs as distinct in unique constraints,
+    # so system instruments (user_id=NULL) are not affected
+    op.create_unique_constraint(
+        'uq_instruments_user_id_name',
+        'instruments',
+        ['user_id', 'name']
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint('uq_instruments_user_id_name', 'instruments', type_='unique')
+
+

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -11,6 +11,7 @@ export default function Home() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [needsOnboarding, setNeedsOnboarding] = useState(false)
+  const [copyingInstrumentId, setCopyingInstrumentId] = useState<number | null>(null)
   const router = useRouter()
   const api = useApi()
   const { isLoaded, isSignedIn } = useUser()
@@ -46,16 +47,21 @@ export default function Home() {
   }, [isLoaded, isSignedIn, router, api])
 
   const handleCopySystemTemplate = async (instrumentId: number) => {
+    // Prevent double-clicks
+    if (copyingInstrumentId !== null) return
+
+    setCopyingInstrumentId(instrumentId)
     try {
       // Copy the system instrument
       await api.copyInstrument(instrumentId)
-      
+
       // Refresh instruments list
       const data = await api.getInstruments()
       setInstruments(data)
       setNeedsOnboarding(false)
     } catch (err: any) {
       setError(err.message)
+      setCopyingInstrumentId(null)
     }
   }
 
@@ -118,18 +124,57 @@ export default function Home() {
               Select an instrument to add to your practice journal. We&apos;ll set you up with a practice template to get started!
             </p>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              {systemInstruments.map((instrument: Instrument) => (
-                <button
-                  key={instrument.id}
-                  onClick={() => handleCopySystemTemplate(instrument.id)}
-                  className="p-6 bg-gradient-to-br from-primary-500 to-primary-600 text-white rounded-lg shadow-md hover:shadow-xl transition-all hover:scale-105"
-                >
-                  <h3 className="text-2xl font-bold mb-2">{instrument.name}</h3>
-                  {instrument.description && (
-                    <p className="text-primary-100">{instrument.description}</p>
-                  )}
-                </button>
-              ))}
+              {systemInstruments.map((instrument: Instrument) => {
+                const isLoading = copyingInstrumentId === instrument.id
+                const isDisabled = copyingInstrumentId !== null
+                return (
+                  <button
+                    key={instrument.id}
+                    onClick={() => handleCopySystemTemplate(instrument.id)}
+                    disabled={isDisabled}
+                    className={`p-6 bg-gradient-to-br from-primary-500 to-primary-600 text-white rounded-lg shadow-md transition-all ${
+                      isDisabled
+                        ? 'opacity-70 cursor-not-allowed'
+                        : 'hover:shadow-xl hover:scale-105'
+                    }`}
+                  >
+                    {isLoading ? (
+                      <>
+                        <div className="flex items-center justify-center mb-2">
+                          <svg
+                            className="animate-spin h-8 w-8 text-white"
+                            xmlns="http://www.w3.org/2000/svg"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                          >
+                            <circle
+                              className="opacity-25"
+                              cx="12"
+                              cy="12"
+                              r="10"
+                              stroke="currentColor"
+                              strokeWidth="4"
+                            />
+                            <path
+                              className="opacity-75"
+                              fill="currentColor"
+                              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                            />
+                          </svg>
+                        </div>
+                        <p className="text-primary-100">Setting up...</p>
+                      </>
+                    ) : (
+                      <>
+                        <h3 className="text-2xl font-bold mb-2">{instrument.name}</h3>
+                        {instrument.description && (
+                          <p className="text-primary-100">{instrument.description}</p>
+                        )}
+                      </>
+                    )}
+                  </button>
+                )
+              })}
             </div>
           </div>
         </div>


### PR DESCRIPTION
Frontend:
- Add loading state to track which instrument is being copied
- Disable all instrument buttons while a copy is in progress
- Show spinner and "Setting up..." text on the clicked button

Backend:
- Add unique constraint on (user_id, name) for instruments table
- Migration cleans up any existing duplicates before adding constraint