### PR TITLE
Refactor frontend to use UserInstrument junction table

### DIFF
--- a/frontend/src/app/[instrument]/history/page.tsx
+++ b/frontend/src/app/[instrument]/history/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { useApi } from '@/lib/useApi'
-import type { Instrument, PracticeTemplate, PracticeLog, AnalyticsSummary as AnalyticsType } from '@/lib/types'
+import type { UserInstrument, PracticeTemplate, PracticeLog, AnalyticsSummary as AnalyticsType } from '@/lib/types'
 import AnalyticsSummary from '@/components/AnalyticsSummary'
 import HistoryCard from '@/components/HistoryCard'
 
@@ -20,19 +20,15 @@ export default function HistoryPage() {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const [instruments, allTemplates] = await Promise.all([
-          api.getInstruments(),
-          api.getTemplates(),
-        ])
+        const userInstruments = await api.getUserInstruments()
 
-        const inst = instruments.find(
-          (i) => i.name.toLowerCase() === instrumentName.toLowerCase()
+        const ui = userInstruments.find(
+          (ui) => ui.instrument.name.toLowerCase() === instrumentName.toLowerCase()
         )
 
-        if (inst) {
-          const tmpl = allTemplates.find(
-            (t) => t.instrument_id === inst.id && t.is_active
-          )
+        if (ui) {
+          const allTemplates = await api.getTemplates(ui.id)
+          const tmpl = allTemplates.find((t) => t.is_active)
 
           if (tmpl) {
             const [templateData, logsData, analyticsData] = await Promise.all([

--- a/frontend/src/app/[instrument]/log/page.tsx
+++ b/frontend/src/app/[instrument]/log/page.tsx
@@ -6,7 +6,7 @@ import { useApi } from '@/lib/useApi'
 import OutcomeSelector from '@/components/OutcomeSelector'
 import SuggestionCard from '@/components/SuggestionCard'
 import { evaluateRules } from '@/lib/progressionRules'
-import type { PracticeTemplate, PracticeDay, BlockType, Exercise, PracticeOutcome, Suggestion, Instrument } from '@/lib/types'
+import type { PracticeTemplate, PracticeDay, BlockType, Exercise, PracticeOutcome, Suggestion, UserInstrument } from '@/lib/types'
 
 // Track exercise selection with outcome
 interface ExerciseSelection {
@@ -21,7 +21,7 @@ export default function LogPracticePage() {
   const router = useRouter()
   const api = useApi()
   const instrumentName = params.instrument as string
-  const [instrument, setInstrument] = useState<Instrument | null>(null)
+  const [userInstrument, setUserInstrument] = useState<UserInstrument | null>(null)
   const [template, setTemplate] = useState<PracticeTemplate | null>(null)
   const [blockTypes, setBlockTypes] = useState<BlockType[]>([])
   const [loading, setLoading] = useState(true)
@@ -49,16 +49,15 @@ export default function LogPracticePage() {
   useEffect(() => {
     api.getBlockTypes().then(setBlockTypes).catch(() => {})
 
-    Promise.all([api.getInstruments(), api.getTemplates()])
-      .then(([instruments, allTemplates]) => {
-        const inst = instruments.find(
-          (i) => i.name.toLowerCase() === instrumentName.toLowerCase()
+    api.getUserInstruments()
+      .then(async (userInstruments) => {
+        const ui = userInstruments.find(
+          (ui) => ui.instrument.name.toLowerCase() === instrumentName.toLowerCase()
         )
-        if (inst) {
-          setInstrument(inst)
-          const tmpl = allTemplates.find(
-            (t) => t.instrument_id === inst.id && t.is_active
-          )
+        if (ui) {
+          setUserInstrument(ui)
+          const allTemplates = await api.getTemplates(ui.id)
+          const tmpl = allTemplates.find((t) => t.is_active)
           if (tmpl) {
             return api.getTemplate(tmpl.id)
           }
@@ -182,9 +181,9 @@ export default function LogPracticePage() {
       }
 
       // Fetch suggestions after logging
-      if (instrument) {
+      if (userInstrument) {
         try {
-          const progressData = await api.getSuggestionsProgress(instrument.id)
+          const progressData = await api.getSuggestionsProgress(userInstrument.instrument.id)
           const newSuggestions = evaluateRules(
             progressData.exercises,
             progressData.progress,

--- a/frontend/src/app/[instrument]/page.tsx
+++ b/frontend/src/app/[instrument]/page.tsx
@@ -3,26 +3,27 @@
 import { useEffect, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { useApi } from '@/lib/useApi'
-import type { Instrument, PracticeTemplate } from '@/lib/types'
+import type { UserInstrument, PracticeTemplate } from '@/lib/types'
 
 export default function InstrumentPage() {
   const params = useParams()
   const router = useRouter()
   const api = useApi()
   const instrumentName = params.instrument as string
-  const [instrument, setInstrument] = useState<Instrument | null>(null)
+  const [userInstrument, setUserInstrument] = useState<UserInstrument | null>(null)
   const [templates, setTemplates] = useState<PracticeTemplate[]>([])
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    Promise.all([api.getInstruments(), api.getTemplates()])
-      .then(([instruments, allTemplates]) => {
-        const inst = instruments.find(
-          (i) => i.name.toLowerCase() === instrumentName.toLowerCase()
+    api.getUserInstruments()
+      .then(async (userInstruments) => {
+        const ui = userInstruments.find(
+          (ui) => ui.instrument.name.toLowerCase() === instrumentName.toLowerCase()
         )
-        if (inst) {
-          setInstrument(inst)
-          setTemplates(allTemplates.filter((t) => t.instrument_id === inst.id))
+        if (ui) {
+          setUserInstrument(ui)
+          const allTemplates = await api.getTemplates(ui.id)
+          setTemplates(allTemplates)
         }
         setLoading(false)
       })
@@ -42,11 +43,17 @@ export default function InstrumentPage() {
     )
   }
 
-  if (!instrument) {
+  if (!userInstrument) {
     return (
       <main className="min-h-screen bg-gradient-to-br from-primary-100 to-secondary-100 p-8">
         <div className="max-w-6xl mx-auto">
           <p className="text-center text-red-600">Instrument not found</p>
+          <button
+            onClick={() => router.push('/me')}
+            className="mt-4 mx-auto block text-primary-600 hover:text-primary-800"
+          >
+            Go to My Instruments
+          </button>
         </div>
       </main>
     )
@@ -57,9 +64,21 @@ export default function InstrumentPage() {
   return (
     <main className="min-h-screen bg-gradient-to-br from-primary-100 to-secondary-100 p-8">
       <div className="max-w-6xl mx-auto">
+        <div className="mb-4">
+          <button
+            onClick={() => router.push('/me')}
+            className="text-primary-600 hover:text-primary-800 flex items-center gap-1"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+            My Instruments
+          </button>
+        </div>
+
         <div className="bg-white rounded-xl shadow-xl overflow-hidden">
           <div className="bg-gradient-to-br from-primary-500 to-primary-700 text-white p-8 text-center">
-            <h1 className="text-4xl font-bold mb-2">🎻 {instrument.name} Practice Tracker</h1>
+            <h1 className="text-4xl font-bold mb-2">{userInstrument.instrument.name} Practice Tracker</h1>
             {activeTemplate && (
               <p className="text-primary-100 text-lg">{activeTemplate.name}</p>
             )}
@@ -71,7 +90,7 @@ export default function InstrumentPage() {
                 onClick={() => router.push(`/${instrumentName}/plan`)}
                 className="p-6 bg-gradient-to-br from-primary-500 to-primary-600 text-white rounded-lg shadow-md hover:shadow-xl transition-all hover:scale-105"
               >
-                <h2 className="text-2xl font-bold mb-2">📅 Practice Plan</h2>
+                <h2 className="text-2xl font-bold mb-2">Practice Plan</h2>
                 <p className="text-primary-100">View your rotation schedule</p>
               </button>
 
@@ -79,7 +98,7 @@ export default function InstrumentPage() {
                 onClick={() => router.push(`/${instrumentName}/log`)}
                 className="p-6 bg-gradient-to-br from-green-500 to-green-600 text-white rounded-lg shadow-md hover:shadow-xl transition-all hover:scale-105"
               >
-                <h2 className="text-2xl font-bold mb-2">✏️ Log Practice</h2>
+                <h2 className="text-2xl font-bold mb-2">Log Practice</h2>
                 <p className="text-green-100">Record today&apos;s session</p>
               </button>
 
@@ -87,7 +106,7 @@ export default function InstrumentPage() {
                 onClick={() => router.push(`/${instrumentName}/history`)}
                 className="p-6 bg-gradient-to-br from-purple-500 to-purple-600 text-white rounded-lg shadow-md hover:shadow-xl transition-all hover:scale-105"
               >
-                <h2 className="text-2xl font-bold mb-2">📊 History</h2>
+                <h2 className="text-2xl font-bold mb-2">History</h2>
                 <p className="text-purple-100">View past sessions & stats</p>
               </button>
 
@@ -95,7 +114,7 @@ export default function InstrumentPage() {
                 onClick={() => router.push(`/${instrumentName}/template/edit`)}
                 className="p-6 bg-gradient-to-br from-amber-500 to-amber-600 text-white rounded-lg shadow-md hover:shadow-xl transition-all hover:scale-105"
               >
-                <h2 className="text-2xl font-bold mb-2">🛠️ Edit Template</h2>
+                <h2 className="text-2xl font-bold mb-2">Edit Template</h2>
                 <p className="text-amber-100">
                   {activeTemplate ? 'Customize your plan' : 'Create a practice plan'}
                 </p>
@@ -107,5 +126,3 @@ export default function InstrumentPage() {
     </main>
   )
 }
-
-

--- a/frontend/src/app/[instrument]/plan/page.tsx
+++ b/frontend/src/app/[instrument]/plan/page.tsx
@@ -5,7 +5,7 @@ import { useParams, useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { useApi } from '@/lib/useApi'
 import { evaluateRules } from '@/lib/progressionRules'
-import type { Instrument, PracticeTemplate, PracticeDay, BlockType, Suggestion } from '@/lib/types'
+import type { UserInstrument, PracticeTemplate, PracticeDay, BlockType, Suggestion } from '@/lib/types'
 import DaySelector from '@/components/DaySelector'
 import PracticeBlock from '@/components/PracticeBlock'
 
@@ -14,7 +14,7 @@ export default function PracticePlanPage() {
   const router = useRouter()
   const api = useApi()
   const instrumentName = params.instrument as string
-  const [instrument, setInstrument] = useState<Instrument | null>(null)
+  const [userInstrument, setUserInstrument] = useState<UserInstrument | null>(null)
   const [template, setTemplate] = useState<PracticeTemplate | null>(null)
   const [selectedDay, setSelectedDay] = useState(1)
   const [currentDayData, setCurrentDayData] = useState<PracticeDay | null>(null)
@@ -25,20 +25,19 @@ export default function PracticePlanPage() {
   useEffect(() => {
     api.getBlockTypes().then(setBlockTypes).catch(() => {})
 
-    Promise.all([api.getInstruments(), api.getTemplates()])
-      .then(async ([instruments, allTemplates]) => {
-        const inst = instruments.find(
-          (i) => i.name.toLowerCase() === instrumentName.toLowerCase()
+    api.getUserInstruments()
+      .then(async (userInstruments) => {
+        const ui = userInstruments.find(
+          (ui) => ui.instrument.name.toLowerCase() === instrumentName.toLowerCase()
         )
-        if (inst) {
-          setInstrument(inst)
-          const tmpl = allTemplates.find(
-            (t) => t.instrument_id === inst.id && t.is_active
-          )
+        if (ui) {
+          setUserInstrument(ui)
+          const allTemplates = await api.getTemplates(ui.id)
+          const tmpl = allTemplates.find((t) => t.is_active)
           if (tmpl) {
             // Fetch suggestions count
             try {
-              const progressData = await api.getSuggestionsProgress(inst.id)
+              const progressData = await api.getSuggestionsProgress(ui.instrument.id)
               const dismissedKeys: Set<string> = typeof window !== 'undefined'
                 ? new Set(JSON.parse(localStorage.getItem(`dismissed_suggestions_${instrumentName}`) || '[]') as string[])
                 : new Set<string>()

--- a/frontend/src/app/[instrument]/suggestions/page.tsx
+++ b/frontend/src/app/[instrument]/suggestions/page.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link'
 import { useApi } from '@/lib/useApi'
 import SuggestionCard from '@/components/SuggestionCard'
 import { evaluateRules } from '@/lib/progressionRules'
-import type { Instrument, Suggestion } from '@/lib/types'
+import type { UserInstrument, Suggestion } from '@/lib/types'
 
 export default function SuggestionsPage() {
   const params = useParams()
@@ -14,7 +14,7 @@ export default function SuggestionsPage() {
   const api = useApi()
   const instrumentName = params.instrument as string
 
-  const [instrument, setInstrument] = useState<Instrument | null>(null)
+  const [userInstrument, setUserInstrument] = useState<UserInstrument | null>(null)
   const [suggestions, setSuggestions] = useState<Suggestion[]>([])
   const [loading, setLoading] = useState(true)
   const [dismissedKeys, setDismissedKeys] = useState<Set<string>>(() => {
@@ -29,19 +29,19 @@ export default function SuggestionsPage() {
   useEffect(() => {
     const loadSuggestions = async () => {
       try {
-        const instruments = await api.getInstruments()
-        const inst = instruments.find(
-          (i) => i.name.toLowerCase() === instrumentName.toLowerCase()
+        const userInstruments = await api.getUserInstruments()
+        const ui = userInstruments.find(
+          (ui) => ui.instrument.name.toLowerCase() === instrumentName.toLowerCase()
         )
 
-        if (!inst) {
-          router.push('/')
+        if (!ui) {
+          router.push('/me')
           return
         }
 
-        setInstrument(inst)
+        setUserInstrument(ui)
 
-        const progressData = await api.getSuggestionsProgress(inst.id)
+        const progressData = await api.getSuggestionsProgress(ui.instrument.id)
         const newSuggestions = evaluateRules(
           progressData.exercises,
           progressData.progress,
@@ -108,7 +108,7 @@ export default function SuggestionsPage() {
           <div className="bg-gradient-to-br from-purple-500 to-purple-700 text-white p-8 text-center">
             <h1 className="text-4xl font-bold mb-2">Suggestions</h1>
             <p className="text-purple-100 text-lg">
-              {instrument?.name} practice recommendations
+              {userInstrument?.instrument.name} practice recommendations
             </p>
           </div>
 

--- a/frontend/src/app/[instrument]/template/edit/page.tsx
+++ b/frontend/src/app/[instrument]/template/edit/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useCallback } from 'react'
 import { useParams, useRouter, useSearchParams } from 'next/navigation'
 import { useApi } from '@/lib/useApi'
-import type { Instrument, PracticeTemplate, BlockType, PracticeDay } from '@/lib/types'
+import type { UserInstrument, PracticeTemplate, BlockType, PracticeDay } from '@/lib/types'
 import DaySelector from '@/components/DaySelector'
 import EditableText from '@/components/builder/EditableText'
 import BlockEditor from '@/components/builder/BlockEditor'
@@ -18,7 +18,7 @@ export default function TemplateEditPage() {
   const instrumentName = params.instrument as string
   const templateIdParam = searchParams.get('templateId')
 
-  const [instrument, setInstrument] = useState<Instrument | null>(null)
+  const [userInstrument, setUserInstrument] = useState<UserInstrument | null>(null)
   const [template, setTemplate] = useState<PracticeTemplate | null>(null)
   const [templates, setTemplates] = useState<PracticeTemplate[]>([])
   const [blockTypes, setBlockTypes] = useState<BlockType[]>([])
@@ -45,24 +45,23 @@ export default function TemplateEditPage() {
   // Initial data load
   useEffect(() => {
     setLoading(true)
-    Promise.all([api.getInstruments(), api.getBlockTypes(), api.getTemplates()])
-      .then(([instruments, bt, allTemplates]) => {
+    Promise.all([api.getUserInstruments(), api.getBlockTypes()])
+      .then(async ([userInstruments, bt]) => {
         setBlockTypes(bt)
-        const inst = instruments.find(
-          (i) => i.name.toLowerCase() === instrumentName.toLowerCase()
+        const ui = userInstruments.find(
+          (ui) => ui.instrument.name.toLowerCase() === instrumentName.toLowerCase()
         )
-        if (!inst) {
+        if (!ui) {
           setLoading(false)
           return
         }
-        setInstrument(inst)
-        setTemplates(allTemplates.filter((t) => t.instrument_id === inst.id))
+        setUserInstrument(ui)
+        const allTemplates = await api.getTemplates(ui.id)
+        setTemplates(allTemplates)
 
         if (templateIdParam) {
-          return api.getTemplate(Number(templateIdParam)).then((tmpl) => {
-            setTemplate(tmpl)
-            setLoading(false)
-          })
+          const tmpl = await api.getTemplate(Number(templateIdParam))
+          setTemplate(tmpl)
         }
         setLoading(false)
       })
@@ -191,10 +190,10 @@ export default function TemplateEditPage() {
   }
 
   async function handleCreateTemplate(data: { name: string; daysCount: number; description?: string }): Promise<number> {
-    if (!instrument) throw new Error('No instrument loaded')
+    if (!userInstrument) throw new Error('No instrument loaded')
     try {
       const tmpl = await api.createTemplate({
-        instrument_id: instrument.id,
+        user_instrument_id: userInstrument.id,
         name: data.name,
         days_count: data.daysCount,
         description: data.description,
@@ -240,7 +239,7 @@ export default function TemplateEditPage() {
     )
   }
 
-  if (!instrument) {
+  if (!userInstrument) {
     return (
       <main className="min-h-screen bg-gradient-to-br from-primary-100 to-secondary-100 p-8">
         <div className="max-w-6xl mx-auto">
@@ -258,7 +257,7 @@ export default function TemplateEditPage() {
           <div className="bg-white rounded-xl shadow-xl overflow-hidden">
             <div className="bg-gradient-to-br from-primary-500 to-primary-700 text-white p-8 text-center">
               <h1 className="text-3xl font-bold">Template Builder</h1>
-              <p className="text-primary-100 mt-1">{instrument.name}</p>
+              <p className="text-primary-100 mt-1">{userInstrument.instrument.name}</p>
             </div>
             <div className="p-8">
               <TemplatePicker

--- a/frontend/src/app/me/page.tsx
+++ b/frontend/src/app/me/page.tsx
@@ -1,0 +1,274 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useApi } from '@/lib/useApi'
+import { useUser } from '@clerk/nextjs'
+import type { UserInstrument, Instrument } from '@/lib/types'
+
+export default function MePage() {
+  const [userInstruments, setUserInstruments] = useState<UserInstrument[]>([])
+  const [availableInstruments, setAvailableInstruments] = useState<Instrument[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [showAddModal, setShowAddModal] = useState(false)
+  const [addingInstrumentId, setAddingInstrumentId] = useState<number | null>(null)
+  const [removingId, setRemovingId] = useState<number | null>(null)
+  const [confirmRemove, setConfirmRemove] = useState<UserInstrument | null>(null)
+  const router = useRouter()
+  const api = useApi()
+  const { isLoaded, isSignedIn } = useUser()
+
+  const fetchData = async () => {
+    try {
+      const [instruments, available] = await Promise.all([
+        api.getUserInstruments(),
+        api.getAvailableInstruments(),
+      ])
+      setUserInstruments(instruments)
+      setAvailableInstruments(available)
+      setLoading(false)
+    } catch (err: any) {
+      setError(err.message)
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    if (!isLoaded) return
+    if (!isSignedIn) {
+      router.push('/sign-in')
+      return
+    }
+    fetchData()
+  }, [isLoaded, isSignedIn, router, api])
+
+  const handleAddInstrument = async (instrumentId: number) => {
+    if (addingInstrumentId !== null) return
+    setAddingInstrumentId(instrumentId)
+    try {
+      await api.addUserInstrument(instrumentId)
+      await fetchData()
+      setShowAddModal(false)
+    } catch (err: any) {
+      setError(err.message)
+    } finally {
+      setAddingInstrumentId(null)
+    }
+  }
+
+  const handleRemoveInstrument = async (userInstrument: UserInstrument, confirmed = false) => {
+    if (userInstrument.template_count > 0 && !confirmed) {
+      setConfirmRemove(userInstrument)
+      return
+    }
+
+    setRemovingId(userInstrument.id)
+    setConfirmRemove(null)
+    try {
+      await api.removeUserInstrument(userInstrument.id, confirmed)
+      await fetchData()
+    } catch (err: any) {
+      setError(err.message)
+    } finally {
+      setRemovingId(null)
+    }
+  }
+
+  if (!isLoaded || loading) {
+    return (
+      <main className="min-h-screen bg-gradient-to-br from-primary-100 to-secondary-100 p-8">
+        <div className="max-w-4xl mx-auto">
+          <h1 className="text-4xl font-bold mb-8 text-primary-700">My Instruments</h1>
+          <div className="bg-white rounded-xl shadow-xl p-8">
+            <p className="text-center text-gray-500">Loading...</p>
+          </div>
+        </div>
+      </main>
+    )
+  }
+
+  if (error) {
+    return (
+      <main className="min-h-screen bg-gradient-to-br from-primary-100 to-secondary-100 p-8">
+        <div className="max-w-4xl mx-auto">
+          <h1 className="text-4xl font-bold mb-8 text-primary-700">My Instruments</h1>
+          <div className="bg-red-50 rounded-xl shadow-xl p-8">
+            <p className="text-center text-red-600">Error: {error}</p>
+          </div>
+        </div>
+      </main>
+    )
+  }
+
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-primary-100 to-secondary-100 p-8">
+      <div className="max-w-4xl mx-auto">
+        <div className="flex justify-between items-center mb-8">
+          <h1 className="text-4xl font-bold text-primary-700">My Instruments</h1>
+          {availableInstruments.length > 0 && (
+            <button
+              onClick={() => setShowAddModal(true)}
+              className="px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors flex items-center gap-2"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+              </svg>
+              Add Instrument
+            </button>
+          )}
+        </div>
+
+        {userInstruments.length === 0 ? (
+          <div className="bg-white rounded-xl shadow-xl p-8 text-center">
+            <h2 className="text-2xl font-semibold mb-4 text-gray-800">Welcome!</h2>
+            <p className="text-gray-600 mb-6">
+              Get started by adding an instrument to your practice journal.
+            </p>
+            <button
+              onClick={() => setShowAddModal(true)}
+              className="px-6 py-3 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors"
+            >
+              Add Your First Instrument
+            </button>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {userInstruments.map((ui) => (
+              <div
+                key={ui.id}
+                className="bg-white rounded-xl shadow-lg overflow-hidden"
+              >
+                <button
+                  onClick={() => router.push(`/${ui.instrument.name.toLowerCase()}`)}
+                  className="w-full p-6 bg-gradient-to-br from-primary-500 to-primary-600 text-white text-left hover:from-primary-600 hover:to-primary-700 transition-all"
+                >
+                  <h3 className="text-2xl font-bold mb-1">{ui.instrument.name}</h3>
+                  {ui.instrument.description && (
+                    <p className="text-primary-100 text-sm">{ui.instrument.description}</p>
+                  )}
+                  <p className="text-primary-200 text-xs mt-2">
+                    {ui.template_count} {ui.template_count === 1 ? 'template' : 'templates'}
+                  </p>
+                </button>
+                <div className="px-4 py-2 bg-gray-50 flex justify-end">
+                  <button
+                    onClick={() => handleRemoveInstrument(ui)}
+                    disabled={removingId === ui.id}
+                    className="text-sm text-red-600 hover:text-red-800 disabled:opacity-50"
+                  >
+                    {removingId === ui.id ? 'Removing...' : 'Remove'}
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Add Instrument Modal */}
+      {showAddModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+          <div className="bg-white rounded-xl shadow-2xl max-w-lg w-full max-h-[80vh] overflow-hidden">
+            <div className="p-6 border-b">
+              <div className="flex justify-between items-center">
+                <h2 className="text-2xl font-bold text-gray-800">Add Instrument</h2>
+                <button
+                  onClick={() => setShowAddModal(false)}
+                  className="text-gray-500 hover:text-gray-700"
+                >
+                  <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <div className="p-6 overflow-y-auto max-h-[60vh]">
+              {availableInstruments.length === 0 ? (
+                <p className="text-gray-500 text-center">No more instruments available to add.</p>
+              ) : (
+                <div className="grid gap-3">
+                  {availableInstruments.map((instrument) => {
+                    const isAdding = addingInstrumentId === instrument.id
+                    return (
+                      <button
+                        key={instrument.id}
+                        onClick={() => handleAddInstrument(instrument.id)}
+                        disabled={addingInstrumentId !== null}
+                        className={`p-4 border rounded-lg text-left transition-all ${
+                          addingInstrumentId !== null
+                            ? 'opacity-70 cursor-not-allowed'
+                            : 'hover:border-primary-500 hover:bg-primary-50'
+                        }`}
+                      >
+                        <div className="flex justify-between items-center">
+                          <div>
+                            <h3 className="font-semibold text-gray-800">{instrument.name}</h3>
+                            {instrument.description && (
+                              <p className="text-sm text-gray-500">{instrument.description}</p>
+                            )}
+                          </div>
+                          {isAdding && (
+                            <svg
+                              className="animate-spin h-5 w-5 text-primary-600"
+                              xmlns="http://www.w3.org/2000/svg"
+                              fill="none"
+                              viewBox="0 0 24 24"
+                            >
+                              <circle
+                                className="opacity-25"
+                                cx="12"
+                                cy="12"
+                                r="10"
+                                stroke="currentColor"
+                                strokeWidth="4"
+                              />
+                              <path
+                                className="opacity-75"
+                                fill="currentColor"
+                                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                              />
+                            </svg>
+                          )}
+                        </div>
+                      </button>
+                    )
+                  })}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Confirm Remove Modal */}
+      {confirmRemove && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+          <div className="bg-white rounded-xl shadow-2xl max-w-md w-full p-6">
+            <h2 className="text-xl font-bold text-gray-800 mb-4">Remove Instrument?</h2>
+            <p className="text-gray-600 mb-4">
+              Removing <strong>{confirmRemove.instrument.name}</strong> will also delete{' '}
+              <strong>{confirmRemove.template_count}</strong>{' '}
+              {confirmRemove.template_count === 1 ? 'template' : 'templates'}.
+            </p>
+            <p className="text-red-600 text-sm mb-6">This action cannot be undone.</p>
+            <div className="flex gap-3 justify-end">
+              <button
+                onClick={() => setConfirmRemove(null)}
+                className="px-4 py-2 text-gray-600 hover:text-gray-800"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => handleRemoveInstrument(confirmRemove, true)}
+                className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700"
+              >
+                Remove Instrument
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </main>
+  )
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,76 +1,28 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
-import { useApi } from '@/lib/useApi'
 import { useUser } from '@clerk/nextjs'
-import type { Instrument } from '@/lib/types'
 
 export default function Home() {
-  const [instruments, setInstruments] = useState<Instrument[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const [needsOnboarding, setNeedsOnboarding] = useState(false)
-  const [copyingInstrumentId, setCopyingInstrumentId] = useState<number | null>(null)
   const router = useRouter()
-  const api = useApi()
   const { isLoaded, isSignedIn } = useUser()
 
   useEffect(() => {
-    // Wait for Clerk to load
     if (!isLoaded) return
 
-    // Redirect to sign-in if not authenticated
-    if (!isSignedIn) {
+    if (isSignedIn) {
+      router.push('/me')
+    } else {
       router.push('/sign-in')
-      return
     }
+  }, [isLoaded, isSignedIn, router])
 
-    // Fetch instruments
-    api
-      .getInstruments()
-      .then((data) => {
-        setInstruments(data)
-        
-        // Check if user needs onboarding (has no user-owned instruments)
-        const userInstruments = data.filter(i => !i.is_system)
-        if (userInstruments.length === 0 && data.some(i => i.is_system)) {
-          setNeedsOnboarding(true)
-        }
-        
-        setLoading(false)
-      })
-      .catch((err) => {
-        setError(err.message)
-        setLoading(false)
-      })
-  }, [isLoaded, isSignedIn, router, api])
-
-  const handleCopySystemTemplate = async (instrumentId: number) => {
-    // Prevent double-clicks
-    if (copyingInstrumentId !== null) return
-
-    setCopyingInstrumentId(instrumentId)
-    try {
-      // Copy the system instrument
-      await api.copyInstrument(instrumentId)
-
-      // Refresh instruments list
-      const data = await api.getInstruments()
-      setInstruments(data)
-      setNeedsOnboarding(false)
-    } catch (err: any) {
-      setError(err.message)
-      setCopyingInstrumentId(null)
-    }
-  }
-
-  if (!isLoaded || loading) {
-    return (
-      <main className="min-h-screen bg-gradient-to-br from-primary-100 to-secondary-100 p-8">
-        <div className="max-w-4xl mx-auto">
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-primary-100 to-secondary-100 p-8">
+      <div className="max-w-4xl mx-auto">
         <h1 className="text-5xl font-bold mb-4 text-center text-primary-700">
-          🎼 Practice Journal
+          Practice Journal
         </h1>
         <p className="text-center text-gray-600 mb-8 text-lg">
           Track your music practice across multiple instruments
@@ -78,143 +30,7 @@ export default function Home() {
         <div className="bg-white rounded-xl shadow-xl p-8">
           <p className="text-center text-gray-500">Loading...</p>
         </div>
-        </div>
-      </main>
-    )
-  }
-
-  if (error) {
-    return (
-      <main className="min-h-screen bg-gradient-to-br from-primary-100 to-secondary-100 p-8">
-        <div className="max-w-4xl mx-auto">
-        <h1 className="text-5xl font-bold mb-4 text-center text-primary-700">
-          🎼 Practice Journal
-        </h1>
-        <div className="bg-red-50 rounded-xl shadow-xl p-8">
-          <p className="text-center text-red-600">
-            Error: {error}
-          </p>
-          <p className="text-center text-gray-600 mt-4">
-            Make sure the backend server is running.
-          </p>
-        </div>
-        </div>
-      </main>
-    )
-  }
-
-  // Show onboarding for new users
-  if (needsOnboarding) {
-    const systemInstruments = instruments.filter(i => i.is_system)
-    
-    return (
-      <main className="min-h-screen bg-gradient-to-br from-primary-100 to-secondary-100 p-8">
-        <div className="max-w-4xl mx-auto">
-          <h1 className="text-5xl font-bold mb-4 text-center text-primary-700">
-            🎉 Welcome to Practice Journal!
-          </h1>
-          <p className="text-center text-gray-600 mb-8 text-lg">
-            Get started by choosing an instrument to practice
-          </p>
-          <div className="bg-white rounded-xl shadow-xl p-8">
-            <h2 className="text-2xl font-semibold mb-4 text-gray-800">
-              Choose Your Instrument
-            </h2>
-            <p className="text-gray-600 mb-6">
-              Select an instrument to add to your practice journal. We&apos;ll set you up with a practice template to get started!
-            </p>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              {systemInstruments.map((instrument: Instrument) => {
-                const isLoading = copyingInstrumentId === instrument.id
-                const isDisabled = copyingInstrumentId !== null
-                return (
-                  <button
-                    key={instrument.id}
-                    onClick={() => handleCopySystemTemplate(instrument.id)}
-                    disabled={isDisabled}
-                    className={`p-6 bg-gradient-to-br from-primary-500 to-primary-600 text-white rounded-lg shadow-md transition-all ${
-                      isDisabled
-                        ? 'opacity-70 cursor-not-allowed'
-                        : 'hover:shadow-xl hover:scale-105'
-                    }`}
-                  >
-                    {isLoading ? (
-                      <>
-                        <div className="flex items-center justify-center mb-2">
-                          <svg
-                            className="animate-spin h-8 w-8 text-white"
-                            xmlns="http://www.w3.org/2000/svg"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                          >
-                            <circle
-                              className="opacity-25"
-                              cx="12"
-                              cy="12"
-                              r="10"
-                              stroke="currentColor"
-                              strokeWidth="4"
-                            />
-                            <path
-                              className="opacity-75"
-                              fill="currentColor"
-                              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                            />
-                          </svg>
-                        </div>
-                        <p className="text-primary-100">Setting up...</p>
-                      </>
-                    ) : (
-                      <>
-                        <h3 className="text-2xl font-bold mb-2">{instrument.name}</h3>
-                        {instrument.description && (
-                          <p className="text-primary-100">{instrument.description}</p>
-                        )}
-                      </>
-                    )}
-                  </button>
-                )
-              })}
-            </div>
-          </div>
-        </div>
-      </main>
-    )
-  }
-
-  // Regular home page for existing users
-  const userInstruments = instruments.filter(i => !i.is_system)
-
-  return (
-    <main className="min-h-screen bg-gradient-to-br from-primary-100 to-secondary-100 p-8">
-      <div className="max-w-4xl mx-auto">
-      <h1 className="text-5xl font-bold mb-4 text-center text-primary-700">
-        🎼 Practice Journal
-      </h1>
-      <p className="text-center text-gray-600 mb-8 text-lg">
-        Track your music practice across multiple instruments
-      </p>
-      <div className="bg-white rounded-xl shadow-xl p-8">
-        <h2 className="text-2xl font-semibold mb-6 text-gray-800">
-          Your Instruments
-        </h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {userInstruments.map((instrument: Instrument) => (
-            <button
-              key={instrument.id}
-              onClick={() => router.push(`/${instrument.name.toLowerCase()}`)}
-              className="p-6 bg-gradient-to-br from-primary-500 to-primary-600 text-white rounded-lg shadow-md hover:shadow-xl transition-all hover:scale-105"
-            >
-              <h3 className="text-2xl font-bold mb-2">{instrument.name}</h3>
-              {instrument.description && (
-                <p className="text-primary-100">{instrument.description}</p>
-              )}
-            </button>
-          ))}
-        </div>
-        </div>
       </div>
     </main>
   )
 }
-

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,6 +1,7 @@
 import type {
   BlockType,
   Instrument,
+  UserInstrument,
   PracticeTemplate,
   PracticeDay,
   PracticeLog,
@@ -75,24 +76,43 @@ export function createAuthenticatedAPI(getToken: () => Promise<string | null>) {
   const authFetchAPI = createFetchAPI(getToken)
   
   return {
-    // Instruments
-    getInstruments: () =>
-      authFetchAPI<Instrument[]>('/api/instruments/'),
+    // User Instruments (user's instrument selections)
+    getUserInstruments: () =>
+      authFetchAPI<UserInstrument[]>('/api/user/instruments'),
+
+    addUserInstrument: (instrumentId: number) =>
+      authFetchAPI<UserInstrument>('/api/user/instruments', {
+        method: 'POST',
+        body: JSON.stringify({ instrument_id: instrumentId }),
+      }),
+
+    removeUserInstrument: (id: number, confirm = false) =>
+      authFetchAPI<{ status: string; deleted_templates: number }>(
+        `/api/user/instruments/${id}${confirm ? '?confirm=true' : ''}`,
+        { method: 'DELETE' }
+      ),
+
+    updateUserInstrument: (id: number, data: { display_order?: number }) =>
+      authFetchAPI<UserInstrument>(`/api/user/instruments/${id}`, {
+        method: 'PATCH',
+        body: JSON.stringify(data),
+      }),
+
+    // Available Instruments (system + shareable)
+    getAvailableInstruments: () =>
+      authFetchAPI<Instrument[]>('/api/instruments/available'),
 
     getInstrument: (id: number) =>
       authFetchAPI<Instrument>(`/api/instruments/${id}`),
-
-    copyInstrument: (id: number) =>
-      authFetchAPI<Instrument>(`/api/instruments/${id}/copy`, { method: 'POST' }),
 
     // Block Types
     getBlockTypes: () =>
       authFetchAPI<BlockType[]>('/api/block-types/'),
 
     // Templates
-    getTemplates: (instrumentId?: number) =>
+    getTemplates: (userInstrumentId?: number) =>
       authFetchAPI<PracticeTemplate[]>(
-        `/api/templates/${instrumentId ? `?instrument_id=${instrumentId}` : ''}`
+        `/api/templates/${userInstrumentId ? `?user_instrument_id=${userInstrumentId}` : ''}`
       ),
 
     getTemplate: (id: number) =>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -27,9 +27,20 @@ export interface Instrument {
   id: number
   name: string
   description?: string
-  created_at: string
-  user_id?: number
   is_system: boolean
+  is_shareable?: boolean
+  created_by_user_id?: number
+  created_at?: string
+}
+
+export interface UserInstrument {
+  id: number
+  user_id: number
+  instrument_id: number
+  instrument: Instrument
+  display_order: number
+  added_at: string
+  template_count: number
 }
 
 export interface Exercise {
@@ -64,7 +75,8 @@ export interface PracticeDay {
 
 export interface PracticeTemplate {
   id: number
-  instrument_id: number
+  instrument_id?: number  // For system templates
+  user_instrument_id?: number  // For user templates
   name: string
   days_count: number
   description?: string
@@ -107,7 +119,7 @@ export interface AnalyticsSummary {
 
 // CRUD input types for template builder
 export interface TemplateCreate {
-  instrument_id: number
+  user_instrument_id: number
   name: string
   days_count: number
   description?: string


### PR DESCRIPTION
- Add /me page for managing user instruments
- Update home page to redirect to /me for authenticated users
- Add getUserInstruments, addUserInstrument, removeUserInstrument, getAvailableInstruments API methods
- Add UserInstrument type with instrument relation
- Update all [instrument] pages to use getUserInstruments() and filter templates by user_instrument_id instead of instrument_id
- Update template creation to use user_instrument_id