### PR TITLE
Fix Pydantic forward reference error in UserInstrumentResponse

### DIFF
--- a/backend/app/api/user_instruments.py
+++ b/backend/app/api/user_instruments.py
@@ -16,6 +16,17 @@ from app.auth import get_current_user
 router = APIRouter(prefix="/user/instruments", tags=["user-instruments"])
 
 
+class InstrumentResponse(BaseModel):
+    """Response model for instrument details"""
+    id: int
+    name: str
+    description: Optional[str]
+    is_system: bool
+
+    class Config:
+        from_attributes = True
+
+
 class UserInstrumentResponse(BaseModel):
     """Response model for user instrument with nested instrument details"""
     id: int
@@ -23,19 +34,8 @@ class UserInstrumentResponse(BaseModel):
     instrument_id: int
     display_order: int
     added_at: str
-    instrument: "InstrumentResponse"
+    instrument: InstrumentResponse
     template_count: int = 0
-
-    class Config:
-        from_attributes = True
-
-
-class InstrumentResponse(BaseModel):
-    """Response model for instrument details"""
-    id: int
-    name: str
-    description: Optional[str]
-    is_system: bool
 
     class Config:
         from_attributes = True


### PR DESCRIPTION
## Summary
- Fix build error caused by Pydantic unable to resolve forward reference `InstrumentResponse`
- Move `InstrumentResponse` class definition before `UserInstrumentResponse` so the type is available at import time

## Test plan
- [x] Run `docker compose up --build` and verify backend starts without errors
- [x] Verify `/user/instruments` endpoints work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)