### PR TITLE
Add template delete, archive, and unarchive functionality

### DIFF
--- a/backend/app/api/templates.py
+++ b/backend/app/api/templates.py
@@ -23,15 +23,18 @@ router = APIRouter(prefix="/templates", tags=["templates"])
 async def list_templates(
     instrument_id: Optional[int] = None,
     user_instrument_id: Optional[int] = None,
+    include_archived: bool = False,
     session: AsyncSession = Depends(get_session),
     current_user: User = Depends(get_current_user)
 ):
     """Get all practice templates (user's own + system templates), optionally filtered by instrument."""
     statement = select(PracticeTemplate).where(
-        PracticeTemplate.is_active == True,
         PracticeTemplate.deleted_at == None,
         (PracticeTemplate.user_id == current_user.id) | (PracticeTemplate.is_system == True)
     )
+
+    if not include_archived:
+        statement = statement.where(PracticeTemplate.is_active == True)
 
     # Filter by user_instrument_id (for user templates)
     if user_instrument_id:
@@ -427,6 +430,8 @@ async def update_template(
         template.name = body.name
     if body.description is not None:
         template.description = body.description
+    if body.is_active is not None:
+        template.is_active = body.is_active
 
     if body.days_count is not None and body.days_count != template.days_count:
         old_count = template.days_count

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -295,6 +295,7 @@ class TemplateUpdate(SQLModel):
     name: Optional[str] = None
     description: Optional[str] = None
     days_count: Optional[int] = None
+    is_active: Optional[bool] = None
 
 
 class DayUpdate(SQLModel):

--- a/frontend/src/app/[instrument]/template/edit/page.tsx
+++ b/frontend/src/app/[instrument]/template/edit/page.tsx
@@ -9,6 +9,7 @@ import EditableText from '@/components/builder/EditableText'
 import BlockEditor from '@/components/builder/BlockEditor'
 import AddBlockPanel from '@/components/builder/AddBlockPanel'
 import TemplatePicker from '@/components/builder/TemplatePicker'
+import ConfirmDialog from '@/components/ConfirmDialog'
 
 export default function TemplateEditPage() {
   const params = useParams()
@@ -25,8 +26,22 @@ export default function TemplateEditPage() {
   const [selectedDay, setSelectedDay] = useState(1)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
+  const [showArchived, setShowArchived] = useState(false)
+  const [confirmDeleteTemplate, setConfirmDeleteTemplate] = useState(false)
 
   const clearError = () => setError('')
+
+  const refreshTemplateList = useCallback(
+    async (ui: UserInstrument) => {
+      try {
+        const allTemplates = await api.getTemplates(ui.id, true)
+        setTemplates(allTemplates)
+      } catch (e) {
+        console.error(e)
+      }
+    },
+    [api]
+  )
 
   const refreshTemplate = useCallback(
     async (id: number) => {
@@ -56,7 +71,7 @@ export default function TemplateEditPage() {
           return
         }
         setUserInstrument(ui)
-        const allTemplates = await api.getTemplates(ui.id)
+        const allTemplates = await api.getTemplates(ui.id, true)
         setTemplates(allTemplates)
 
         if (templateIdParam) {
@@ -74,6 +89,44 @@ export default function TemplateEditPage() {
 
   function handleSelectTemplate(templateId: number) {
     router.push(`/${instrumentName}/template/edit?templateId=${templateId}`)
+  }
+
+  async function handleDeleteTemplate(templateId: number) {
+    try {
+      await api.deleteTemplate(templateId)
+      if (template?.id === templateId) {
+        setTemplate(null)
+        router.push(`/${instrumentName}/template/edit`)
+      }
+      if (userInstrument) await refreshTemplateList(userInstrument)
+    } catch (e) {
+      setError('Failed to delete template.')
+      console.error(e)
+    }
+  }
+
+  async function handleArchiveTemplate(templateId: number) {
+    try {
+      await api.updateTemplate(templateId, { is_active: false })
+      if (template?.id === templateId) {
+        setTemplate(null)
+        router.push(`/${instrumentName}/template/edit`)
+      }
+      if (userInstrument) await refreshTemplateList(userInstrument)
+    } catch (e) {
+      setError('Failed to archive template.')
+      console.error(e)
+    }
+  }
+
+  async function handleUnarchiveTemplate(templateId: number) {
+    try {
+      await api.updateTemplate(templateId, { is_active: true })
+      if (userInstrument) await refreshTemplateList(userInstrument)
+    } catch (e) {
+      setError('Failed to unarchive template.')
+      console.error(e)
+    }
   }
 
   async function handleUpdateTemplateName(newName: string) {
@@ -198,6 +251,7 @@ export default function TemplateEditPage() {
         days_count: data.daysCount,
         description: data.description,
       })
+      await refreshTemplateList(userInstrument)
       return tmpl.id
     } catch (e) {
       setError('Failed to create template.')
@@ -264,6 +318,11 @@ export default function TemplateEditPage() {
                 templates={templates}
                 onCreateTemplate={handleCreateTemplate}
                 onSelect={handleSelectTemplate}
+                onDelete={handleDeleteTemplate}
+                onArchive={handleArchiveTemplate}
+                onUnarchive={handleUnarchiveTemplate}
+                showArchived={showArchived}
+                onToggleShowArchived={() => setShowArchived((v) => !v)}
               />
             </div>
           </div>
@@ -293,6 +352,41 @@ export default function TemplateEditPage() {
               className="text-xl text-primary-100"
               inputClassName="text-xl text-white text-center"
             />
+            {/* Template actions in header */}
+            {!template.is_system && (
+              <div className="flex justify-center gap-3 mt-4">
+                {template.is_active ? (
+                  <button
+                    onClick={() => handleArchiveTemplate(template.id)}
+                    className="text-sm text-primary-200 hover:text-white flex items-center gap-1.5 transition-colors"
+                  >
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4" />
+                    </svg>
+                    Archive
+                  </button>
+                ) : (
+                  <button
+                    onClick={() => handleUnarchiveTemplate(template.id)}
+                    className="text-sm text-primary-200 hover:text-white flex items-center gap-1.5 transition-colors"
+                  >
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                    </svg>
+                    Unarchive
+                  </button>
+                )}
+                <button
+                  onClick={() => setConfirmDeleteTemplate(true)}
+                  className="text-sm text-red-300 hover:text-red-100 flex items-center gap-1.5 transition-colors"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  </svg>
+                  Delete
+                </button>
+              </div>
+            )}
           </div>
 
           <div className="p-8">
@@ -377,6 +471,26 @@ export default function TemplateEditPage() {
           </div>
         </div>
       </div>
+
+      {confirmDeleteTemplate && (
+        <ConfirmDialog
+          title="Delete Template?"
+          message={
+            <p>
+              This will permanently delete <strong>{template.name}</strong>. Your practice logs will be preserved.
+              <br />
+              <span className="text-red-600 text-sm mt-2 block">This action cannot be undone.</span>
+            </p>
+          }
+          confirmLabel="Delete Template"
+          confirmVariant="danger"
+          onConfirm={() => {
+            handleDeleteTemplate(template.id)
+            setConfirmDeleteTemplate(false)
+          }}
+          onCancel={() => setConfirmDeleteTemplate(false)}
+        />
+      )}
     </main>
   )
 }

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import type { ReactNode } from 'react'
+
+interface ConfirmDialogProps {
+  title: string
+  message: string | ReactNode
+  confirmLabel: string
+  confirmVariant?: 'danger' | 'default'
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export default function ConfirmDialog({
+  title,
+  message,
+  confirmLabel,
+  confirmVariant = 'default',
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  const confirmClass =
+    confirmVariant === 'danger'
+      ? 'px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700'
+      : 'px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700'
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+      <div className="bg-white rounded-xl shadow-2xl max-w-md w-full p-6">
+        <h2 className="text-xl font-bold text-gray-800 mb-4">{title}</h2>
+        <div className="text-gray-600 mb-6">{message}</div>
+        <div className="flex gap-3 justify-end">
+          <button
+            onClick={onCancel}
+            className="px-4 py-2 text-gray-600 hover:text-gray-800"
+          >
+            Cancel
+          </button>
+          <button onClick={onConfirm} className={confirmClass}>
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/builder/TemplatePicker.tsx
+++ b/frontend/src/components/builder/TemplatePicker.tsx
@@ -3,19 +3,31 @@
 import { useState } from 'react'
 import type { PracticeTemplate } from '@/lib/types'
 import CreateTemplateForm from './CreateTemplateForm'
+import ConfirmDialog from '@/components/ConfirmDialog'
 
 interface TemplatePickerProps {
   templates: PracticeTemplate[]
   onCreateTemplate: (data: { name: string; daysCount: number; description?: string }) => Promise<number>
   onSelect: (templateId: number) => void
+  onDelete: (templateId: number) => void
+  onArchive: (templateId: number) => void
+  onUnarchive: (templateId: number) => void
+  showArchived: boolean
+  onToggleShowArchived: () => void
 }
 
 export default function TemplatePicker({
   templates,
   onCreateTemplate,
   onSelect,
+  onDelete,
+  onArchive,
+  onUnarchive,
+  showArchived,
+  onToggleShowArchived,
 }: TemplatePickerProps) {
   const [showCreate, setShowCreate] = useState(false)
+  const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null)
 
   if (showCreate) {
     return (
@@ -30,41 +42,153 @@ export default function TemplatePicker({
     )
   }
 
+  const activeTemplates = templates.filter((t) => t.is_active)
+  const archivedTemplates = templates.filter((t) => !t.is_active)
+  const displayedTemplates = showArchived ? archivedTemplates : activeTemplates
+
   return (
     <div>
       <h2 className="text-xl font-bold text-gray-800 mb-4">Choose a Template to Edit</h2>
-      {templates.length > 0 && (
+
+      {/* Active / Archived toggle */}
+      <div className="flex gap-1 mb-6 bg-gray-100 rounded-lg p-1 w-fit">
+        <button
+          onClick={() => showArchived && onToggleShowArchived()}
+          className={`px-4 py-1.5 rounded-md text-sm font-medium transition-colors ${
+            !showArchived
+              ? 'bg-white text-gray-800 shadow-sm'
+              : 'text-gray-500 hover:text-gray-700'
+          }`}
+        >
+          Active ({activeTemplates.length})
+        </button>
+        <button
+          onClick={() => !showArchived && onToggleShowArchived()}
+          className={`px-4 py-1.5 rounded-md text-sm font-medium transition-colors ${
+            showArchived
+              ? 'bg-white text-gray-800 shadow-sm'
+              : 'text-gray-500 hover:text-gray-700'
+          }`}
+        >
+          Archived ({archivedTemplates.length})
+        </button>
+      </div>
+
+      {displayedTemplates.length > 0 ? (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
-          {templates.map((t) => (
-            <button
+          {displayedTemplates.map((t) => (
+            <div
               key={t.id}
-              onClick={() => onSelect(t.id)}
-              className="p-4 bg-white border border-gray-200 rounded-lg hover:border-primary-400 hover:shadow-md transition-all text-left"
+              className="p-4 bg-white border border-gray-200 rounded-lg hover:border-primary-400 hover:shadow-md transition-all"
             >
-              <div className="flex items-center gap-2">
-                <span className="font-semibold text-gray-800">{t.name}</span>
-                {t.is_active && (
-                  <span className="text-xs bg-green-100 text-green-700 px-2 py-0.5 rounded-full">
-                    Active
-                  </span>
+              <button
+                onClick={() => onSelect(t.id)}
+                className="w-full text-left"
+              >
+                <div className="flex items-center gap-2">
+                  <span className="font-semibold text-gray-800">{t.name}</span>
+                  {t.is_active ? (
+                    <span className="text-xs bg-green-100 text-green-700 px-2 py-0.5 rounded-full">
+                      Active
+                    </span>
+                  ) : (
+                    <span className="text-xs bg-gray-100 text-gray-500 px-2 py-0.5 rounded-full">
+                      Archived
+                    </span>
+                  )}
+                </div>
+                <div className="text-sm text-gray-500 mt-1">
+                  {t.days_count} day{t.days_count !== 1 ? 's' : ''}
+                </div>
+                {t.description && (
+                  <div className="text-sm text-gray-500 mt-1">{t.description}</div>
                 )}
-              </div>
-              <div className="text-sm text-gray-500 mt-1">
-                {t.days_count} day{t.days_count !== 1 ? 's' : ''}
-              </div>
-              {t.description && (
-                <div className="text-sm text-gray-500 mt-1">{t.description}</div>
+              </button>
+
+              {/* Action buttons */}
+              {!t.is_system && (
+                <div className="flex gap-2 mt-3 pt-3 border-t border-gray-100">
+                  {t.is_active ? (
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        onArchive(t.id)
+                      }}
+                      className="text-xs text-gray-500 hover:text-gray-700 flex items-center gap-1"
+                      title="Archive template"
+                    >
+                      <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4" />
+                      </svg>
+                      Archive
+                    </button>
+                  ) : (
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        onUnarchive(t.id)
+                      }}
+                      className="text-xs text-primary-600 hover:text-primary-800 flex items-center gap-1"
+                      title="Unarchive template"
+                    >
+                      <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                      </svg>
+                      Unarchive
+                    </button>
+                  )}
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      setConfirmDeleteId(t.id)
+                    }}
+                    className="text-xs text-red-500 hover:text-red-700 flex items-center gap-1"
+                    title="Delete template"
+                  >
+                    <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                    </svg>
+                    Delete
+                  </button>
+                </div>
               )}
-            </button>
+            </div>
           ))}
         </div>
+      ) : (
+        <p className="text-gray-500 mb-6">
+          {showArchived ? 'No archived templates.' : 'No templates yet.'}
+        </p>
       )}
-      <button
-        onClick={() => setShowCreate(true)}
-        className="px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 font-medium"
-      >
-        + Create New Template
-      </button>
+
+      {!showArchived && (
+        <button
+          onClick={() => setShowCreate(true)}
+          className="px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 font-medium"
+        >
+          + Create New Template
+        </button>
+      )}
+
+      {confirmDeleteId !== null && (
+        <ConfirmDialog
+          title="Delete Template?"
+          message={
+            <p>
+              This will permanently delete this template. Your practice logs will be preserved.
+              <br />
+              <span className="text-red-600 text-sm mt-2 block">This action cannot be undone.</span>
+            </p>
+          }
+          confirmLabel="Delete Template"
+          confirmVariant="danger"
+          onConfirm={() => {
+            onDelete(confirmDeleteId)
+            setConfirmDeleteId(null)
+          }}
+          onCancel={() => setConfirmDeleteId(null)}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -116,10 +116,13 @@ export function createAuthenticatedAPI(getToken: () => Promise<string | null>) {
       authFetchAPI<BlockType[]>('/api/block-types/'),
 
     // Templates
-    getTemplates: (userInstrumentId?: number) =>
-      authFetchAPI<PracticeTemplate[]>(
-        `/api/templates/${userInstrumentId ? `?user_instrument_id=${userInstrumentId}` : ''}`
-      ),
+    getTemplates: (userInstrumentId?: number, includeArchived?: boolean) => {
+      const params = new URLSearchParams()
+      if (userInstrumentId) params.set('user_instrument_id', String(userInstrumentId))
+      if (includeArchived) params.set('include_archived', 'true')
+      const qs = params.toString()
+      return authFetchAPI<PracticeTemplate[]>(`/api/templates/${qs ? `?${qs}` : ''}`)
+    },
 
     getTemplate: (id: number) =>
       authFetchAPI<PracticeTemplate>(`/api/templates/${id}`),

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -129,6 +129,7 @@ export interface TemplateUpdate {
   name?: string
   description?: string
   days_count?: number
+  is_active?: boolean
 }
 
 export interface DayUpdate {


### PR DESCRIPTION
Wire up existing backend soft-delete and is_active fields to new frontend controls. Templates can now be archived (hidden but recoverable) or deleted (permanent soft-delete) from both the template picker and builder views.

- Add is_active to TemplateUpdate schema and include_archived query param
- Create reusable ConfirmDialog component
- Add Active/Archived tabs, action buttons, and status badges to TemplatePicker
- Add archive/delete controls to template builder header