### PR TITLE
Allow freeform sections in template mode with skippable blocks (#52)

### DIFF
--- a/backend/app/api/analytics.py
+++ b/backend/app/api/analytics.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException
-from sqlmodel import select, func
+from sqlmodel import select, func, or_
 from sqlmodel.ext.asyncio.session import AsyncSession
 from typing import Optional
 
@@ -24,61 +24,59 @@ async def get_analytics(
     )
     template_result = await session.exec(template_statement)
     user_template_ids = list(template_result.all())
-    
-    if not user_template_ids:
-        # No templates, return empty analytics
-        return AnalyticsSummary(
-            total_sessions=0,
-            total_minutes=0,
-            average_duration=0.0,
-            sessions_by_day={}
-        )
-    
-    # Filter by specific template if provided
+
+    # Build the ownership filter for logs
     if template_id:
-        # Verify user has access to this template
+        # Specific template requested — verify access
         if template_id not in user_template_ids:
             raise HTTPException(status_code=404, detail="Template not found")
-        filter_template_ids = [template_id]
+        log_owner_filter = PracticeLog.template_id == template_id
     else:
-        filter_template_ids = user_template_ids
-    
+        # All logs: those tied to user's templates OR freeform (NULL template_id)
+        log_owner_filter = or_(
+            PracticeLog.template_id.in_(user_template_ids) if user_template_ids else False,  # type: ignore[attr-defined]
+            PracticeLog.template_id == None,  # noqa: E711  # freeform logs
+        )
+
     # Get total sessions (excluding soft-deleted logs)
     count_statement = select(func.count(PracticeLog.id)).where(  # type: ignore[arg-type]
-        PracticeLog.template_id.in_(filter_template_ids),  # type: ignore[attr-defined]
+        PracticeLog.user_id == current_user.id,
+        log_owner_filter,
         PracticeLog.deleted_at == None
     )
-    
+
     result = await session.exec(count_statement)
     total_sessions = result.one() or 0
-    
+
     # Get total minutes (excluding soft-deleted logs)
     sum_statement = select(func.sum(PracticeLog.duration_minutes)).where(  # type: ignore[arg-type]
-        PracticeLog.template_id.in_(filter_template_ids),  # type: ignore[attr-defined]
+        PracticeLog.user_id == current_user.id,
+        log_owner_filter,
         PracticeLog.deleted_at == None
     )
-    
+
     result = await session.exec(sum_statement)
     total_minutes = result.one() or 0
-    
+
     # Calculate average duration
     average_duration = total_minutes / total_sessions if total_sessions > 0 else 0
-    
+
     # Get sessions by day number (excluding soft-deleted logs)
     sessions_by_day = {}
     day_statement = (
         select(PracticeLog.day_number, func.count(PracticeLog.id).label('count'))  # type: ignore[arg-type]
         .where(
-            PracticeLog.template_id.in_(filter_template_ids),  # type: ignore[attr-defined]
+            PracticeLog.user_id == current_user.id,
+            log_owner_filter,
             PracticeLog.deleted_at == None
         )
         .group_by(PracticeLog.day_number)  # type: ignore[arg-type]
     )
-    
+
     result = await session.exec(day_statement)
     for row in result:
         sessions_by_day[str(row[0])] = row[1]  # row is tuple: (day_number, count)
-    
+
     return AnalyticsSummary(
         total_sessions=total_sessions,
         total_minutes=int(total_minutes),

--- a/backend/app/api/logs.py
+++ b/backend/app/api/logs.py
@@ -9,8 +9,8 @@ from typing import List, Optional
 
 from app.database import get_session
 from app.models import (
-    PracticeLog, PracticeLogDetail, PracticeLogCreate, PracticeTemplate, User,
-    ExerciseProgress, PracticeOutcome
+    PracticeLog, PracticeLogDetail, PracticeLogCreate, PracticeLogRead,
+    PracticeTemplate, User, ExerciseProgress, PracticeOutcome
 )
 from app.auth import get_current_user
 from sqlalchemy import func
@@ -18,7 +18,7 @@ from sqlalchemy import func
 router = APIRouter(prefix="/logs", tags=["logs"])
 
 
-@router.post("/", response_model=PracticeLog, status_code=201)
+@router.post("/", response_model=PracticeLogRead, status_code=201)
 async def create_practice_log(
     log_data: PracticeLogCreate,
     session: AsyncSession = Depends(get_session),
@@ -90,7 +90,7 @@ async def create_practice_log(
     return result.scalar_one()
 
 
-@router.get("/", response_model=List[PracticeLog])
+@router.get("/", response_model=List[PracticeLogRead])
 async def list_practice_logs(
     template_id: Optional[int] = None,
     limit: int = 50,
@@ -124,6 +124,9 @@ async def list_practice_logs(
     
     result = await session.exec(statement)
     logs = result.all()
+    # Access relationship to ensure it's included in serialization
+    for log in logs:
+        _ = log.log_details
     return logs
 
 
@@ -147,7 +150,7 @@ async def get_section_types(
     return list(result.all())
 
 
-@router.get("/{log_id}", response_model=PracticeLog)
+@router.get("/{log_id}", response_model=PracticeLogRead)
 async def get_practice_log(
     log_id: int,
     session: AsyncSession = Depends(get_session),

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -265,6 +265,38 @@ class PracticeLogDetail(SQLModel, table=True):
 
 # API-specific models (for requests/responses that differ from DB models)
 
+class PracticeLogDetailRead(SQLModel):
+    """Response schema for log details — explicit fields, no relationship ambiguity."""
+    model_config = {"from_attributes": True}
+
+    id: int
+    log_id: int
+    section_type: str
+    content: Optional[str] = None
+    exercise_id: Optional[int] = None
+    tempo_practiced: Optional[int] = None
+    outcome: Optional[str] = None
+    notes: Optional[str] = None
+    key_practiced: Optional[str] = None
+    time_signature: Optional[str] = None
+    duration_minutes: Optional[int] = None
+
+
+class PracticeLogRead(SQLModel):
+    """Response schema for practice logs — ensures log_details is always serialized."""
+    model_config = {"from_attributes": True}
+
+    id: int
+    user_id: int
+    template_id: Optional[int] = None
+    day_number: Optional[int] = None
+    practice_date: date
+    duration_minutes: int
+    notes: Optional[str] = None
+    created_at: datetime
+    log_details: List[PracticeLogDetailRead] = []
+
+
 class PracticeLogDetailCreate(SQLModel):
     """Schema for creating log details"""
     section_type: str

--- a/frontend/src/app/[instrument]/history/page.tsx
+++ b/frontend/src/app/[instrument]/history/page.tsx
@@ -30,17 +30,16 @@ export default function HistoryPage() {
           const allTemplates = await api.getTemplates(ui.id)
           const tmpl = allTemplates.find((t) => t.is_active)
 
-          if (tmpl) {
-            const [templateData, logsData, analyticsData] = await Promise.all([
-              api.getTemplate(tmpl.id),
-              api.getLogs(tmpl.id),
-              api.getAnalytics(tmpl.id),
-            ])
+          // Fetch logs and analytics without template filter so freeform logs are included
+          const [templateData, logsData, analyticsData] = await Promise.all([
+            tmpl ? api.getTemplate(tmpl.id) : Promise.resolve(null),
+            api.getLogs(),
+            api.getAnalytics(),
+          ])
 
-            setTemplate(templateData)
-            setLogs(logsData)
-            setAnalytics(analyticsData)
-          }
+          setTemplate(templateData)
+          setLogs(logsData)
+          setAnalytics(analyticsData)
         }
       } catch (err) {
         console.error(err)
@@ -57,16 +56,6 @@ export default function HistoryPage() {
       <main className="min-h-screen bg-gradient-to-br from-primary-100 to-secondary-100 p-8">
         <div className="max-w-6xl mx-auto">
           <p className="text-center text-gray-600">Loading history...</p>
-        </div>
-      </main>
-    )
-  }
-
-  if (!template) {
-    return (
-      <main className="min-h-screen bg-gradient-to-br from-primary-100 to-secondary-100 p-8">
-        <div className="max-w-6xl mx-auto">
-          <p className="text-center text-red-600">No active template found</p>
         </div>
       </main>
     )
@@ -94,7 +83,7 @@ export default function HistoryPage() {
             ) : (
               <div>
                 {logs.map((log) => {
-                  const dayData = template.practice_days?.find(
+                  const dayData = template?.practice_days?.find(
                     (d) => d.day_number === log.day_number
                   )
                   return (

--- a/frontend/src/app/[instrument]/log/page.tsx
+++ b/frontend/src/app/[instrument]/log/page.tsx
@@ -43,11 +43,22 @@ export default function LogPracticePage() {
   // Track exercise selections with outcomes (keyed by block id)
   const [exerciseSelections, setExerciseSelections] = useState<Record<number, ExerciseSelection>>({})
   const [blockNotes, setBlockNotes] = useState<Record<number, string>>({})
+  const [dismissedBlocks, setDismissedBlocks] = useState<Set<number>>(new Set())
 
   const [freeformSections, setFreeformSections] = useState<
     { label: string; content: string; duration_minutes?: number; tempo_practiced?: number; key_practiced?: string; time_signature?: string }[]
   >([])
   const [sectionSuggestions, setSectionSuggestions] = useState<string[]>([])
+
+  // Save-as-template state
+  const [submittedFreeformSections, setSubmittedFreeformSections] = useState<
+    typeof freeformSections
+  >([])
+  const [submittedInFreeformMode, setSubmittedInFreeformMode] = useState(false)
+  const [showSaveAsTemplate, setShowSaveAsTemplate] = useState(false)
+  const [templateName, setTemplateName] = useState('')
+  const [savingTemplate, setSavingTemplate] = useState(false)
+  const [savedTemplateId, setSavedTemplateId] = useState<number | null>(null)
 
   useEffect(() => {
     // Fetch block types and section type suggestions, then merge for combobox
@@ -103,6 +114,7 @@ export default function LogPracticePage() {
   useEffect(() => {
     setBlockNotes({})
     setExerciseSelections({})
+    setDismissedBlocks(new Set())
   }, [formData.dayNumber])
 
   const getCurrentDay = (): PracticeDay | undefined => {
@@ -210,13 +222,24 @@ export default function LogPracticePage() {
               })
           : []
 
+        const freeformDetails = freeformSections
+          .filter((s) => s.content && s.label.trim())
+          .map((s) => ({
+            section_type: s.label.toLowerCase().replace(/\s+/g, '-'),
+            content: s.content,
+            duration_minutes: s.duration_minutes,
+            tempo_practiced: s.tempo_practiced,
+            key_practiced: s.key_practiced,
+            time_signature: s.time_signature,
+          }))
+
         await api.createLog({
           template_id: template!.id,
           day_number: formData.dayNumber,
           practice_date: formData.date,
           duration_minutes: parseInt(formData.duration),
           notes: formData.notes,
-          log_details: logDetails,
+          log_details: [...logDetails, ...freeformDetails],
         })
       }
 
@@ -235,6 +258,12 @@ export default function LogPracticePage() {
         }
       }
 
+      // Preserve freeform sections for save-as-template prompt
+      setSubmittedFreeformSections(
+        freeformSections.filter((s) => s.content && s.label.trim())
+      )
+      setSubmittedInFreeformMode(freeformMode)
+
       setShowSuccess(true)
       setFormData({
         date: new Date().toISOString().split('T')[0],
@@ -244,6 +273,7 @@ export default function LogPracticePage() {
       })
       setBlockNotes({})
       setExerciseSelections({})
+      setDismissedBlocks(new Set())
       setFreeformSections([])
     } catch (err) {
       console.error(err)
@@ -259,6 +289,14 @@ export default function LogPracticePage() {
 
   const removeFreeformSection = (index: number) => {
     setFreeformSections(freeformSections.filter((_, i) => i !== index))
+  }
+
+  const moveFreeformSection = (index: number, direction: 'up' | 'down') => {
+    const target = direction === 'up' ? index - 1 : index + 1
+    if (target < 0 || target >= freeformSections.length) return
+    const updated = [...freeformSections]
+    ;[updated[index], updated[target]] = [updated[target], updated[index]]
+    setFreeformSections(updated)
   }
 
   const handleAcceptSuggestion = async (suggestion: Suggestion) => {
@@ -287,9 +325,59 @@ export default function LogPracticePage() {
     setSuggestions(suggestions.filter((s) => s.key !== suggestion.key))
   }
 
+  const handleSaveAsTemplate = async () => {
+    if (!userInstrument || !templateName.trim()) return
+    setSavingTemplate(true)
+    try {
+      const newTemplate = await api.createTemplate({
+        user_instrument_id: userInstrument.id,
+        name: templateName.trim(),
+        days_count: 1,
+      })
+
+      for (let i = 0; i < submittedFreeformSections.length; i++) {
+        const section = submittedFreeformSections[i]
+        // Match section label to a block type by label or slug; fall back to "technique"
+        const matchedType = blockTypes.find(
+          (bt) =>
+            bt.label.toLowerCase() === section.label.toLowerCase() ||
+            bt.slug.toLowerCase() === section.label.toLowerCase().replace(/\s+/g, '-')
+        )
+        const fallbackType = blockTypes.find((bt) => bt.slug === 'technique')
+        const blockTypeId = matchedType?.id ?? fallbackType?.id ?? blockTypes[0]?.id
+
+        const block = await api.createBlock(newTemplate.id, 1, {
+          block_type_id: blockTypeId,
+          duration_minutes: section.duration_minutes,
+          display_order: i + 1,
+        })
+
+        await api.createExercise(newTemplate.id, 1, block.id, {
+          exercise_text: section.content,
+          tempo_bpm: section.tempo_practiced,
+          key: section.key_practiced,
+          display_order: 1,
+        })
+      }
+
+      setSavedTemplateId(newTemplate.id)
+    } catch (err) {
+      console.error('Failed to save template:', err)
+      alert('Error saving template')
+    } finally {
+      setSavingTemplate(false)
+    }
+  }
+
   const handleLogAnother = () => {
     setShowSuccess(false)
     setSuggestions([])
+    setSubmittedFreeformSections([])
+    setSubmittedInFreeformMode(false)
+    setShowSaveAsTemplate(false)
+    setTemplateName('')
+    setSavingTemplate(false)
+    setSavedTemplateId(null)
   }
 
   const updateFreeformSection = (
@@ -358,6 +446,58 @@ export default function LogPracticePage() {
                         suggestions page
                       </a>
                     </p>
+                  )}
+                </div>
+              )}
+
+              {/* Save as template prompt (freeform submissions with sections only) */}
+              {submittedInFreeformMode && submittedFreeformSections.length > 0 && (
+                <div className="mb-8">
+                  {savedTemplateId ? (
+                    <div className="border border-green-300 bg-green-50 rounded-lg p-4 text-center">
+                      <p className="text-green-700 font-medium mb-1">Template saved!</p>
+                      <a
+                        href={`/${instrumentName}/template/edit?templateId=${savedTemplateId}`}
+                        className="text-primary-600 hover:underline text-sm"
+                      >
+                        Edit template
+                      </a>
+                    </div>
+                  ) : showSaveAsTemplate ? (
+                    <div className="border border-gray-200 rounded-lg p-4">
+                      <p className="text-sm text-gray-500 mb-3">
+                        Sections: {submittedFreeformSections.map((s) => s.label).join(', ')}
+                      </p>
+                      <div className="flex gap-2">
+                        <input
+                          type="text"
+                          value={templateName}
+                          onChange={(e) => setTemplateName(e.target.value)}
+                          placeholder="Template name"
+                          className="flex-1 px-3 py-2 border-2 border-gray-200 rounded-lg focus:border-primary-500 focus:outline-none text-sm"
+                        />
+                        <button
+                          onClick={handleSaveAsTemplate}
+                          disabled={savingTemplate || !templateName.trim()}
+                          className="px-4 py-2 bg-primary-600 text-white rounded-lg text-sm font-medium hover:bg-primary-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+                        >
+                          {savingTemplate ? 'Saving...' : 'Save'}
+                        </button>
+                        <button
+                          onClick={() => setShowSaveAsTemplate(false)}
+                          className="px-3 py-2 text-gray-500 hover:text-gray-700 text-sm"
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    <button
+                      onClick={() => setShowSaveAsTemplate(true)}
+                      className="w-full border-2 border-dashed border-gray-300 rounded-lg p-4 text-gray-500 hover:border-primary-400 hover:text-primary-600 transition-colors text-sm"
+                    >
+                      Save this session structure as a template
+                    </button>
                   )}
                 </div>
               )}
@@ -476,16 +616,26 @@ export default function LogPracticePage() {
             </div>
 
             {/* Template-based block sections */}
-            {!freeformMode && sortedBlocks.map((block) => (
+            {!freeformMode && sortedBlocks.filter((b) => !dismissedBlocks.has(b.id)).map((block) => (
               <div key={block.id} className="mb-6">
-                <label className="block font-semibold text-gray-700 mb-2">
-                  {getBlockLabel(block)}
-                  {block.duration_minutes && (
-                    <span className="ml-2 text-sm font-normal text-gray-500">
-                      ({block.duration_minutes} min)
-                    </span>
-                  )}
-                </label>
+                <div className="flex items-center justify-between mb-2">
+                  <label className="block font-semibold text-gray-700">
+                    {getBlockLabel(block)}
+                    {block.duration_minutes && (
+                      <span className="ml-2 text-sm font-normal text-gray-500">
+                        ({block.duration_minutes} min)
+                      </span>
+                    )}
+                  </label>
+                  <button
+                    type="button"
+                    onClick={() => setDismissedBlocks(new Set([...dismissedBlocks, block.id]))}
+                    className="text-gray-400 hover:text-red-500 text-sm transition-colors"
+                    title="Skip this section"
+                  >
+                    Skip
+                  </button>
+                </div>
 
                 {block.exercises.length > 0 ? (
                   <div className="space-y-3">
@@ -539,10 +689,11 @@ export default function LogPracticePage() {
             ))}
 
             {/* Freeform sections */}
-            {freeformMode && (
               <div className="mb-6">
                 <div className="flex items-center justify-between mb-4">
-                  <h3 className="font-semibold text-gray-700">Sections</h3>
+                  <h3 className="font-semibold text-gray-700">
+                    {freeformMode ? 'Sections' : 'Additional sections'}
+                  </h3>
                   <button
                     type="button"
                     onClick={addFreeformSection}
@@ -552,7 +703,7 @@ export default function LogPracticePage() {
                   </button>
                 </div>
 
-                {freeformSections.length === 0 && (
+                {freeformMode && freeformSections.length === 0 && (
                   <p className="text-gray-400 italic text-sm mb-4">
                     No sections added. Click &quot;Add section&quot; to log
                     specific areas of practice.
@@ -591,6 +742,26 @@ export default function LogPracticePage() {
                           className="w-16 px-2 py-2 border-2 border-gray-200 rounded-lg focus:border-primary-500 focus:outline-none text-sm text-center"
                         />
                         <span className="text-xs text-gray-400">min</span>
+                      </div>
+                      <div className="flex items-center gap-1">
+                        <button
+                          type="button"
+                          onClick={() => moveFreeformSection(index, 'up')}
+                          disabled={index === 0}
+                          className="p-1 text-gray-400 hover:text-gray-700 disabled:opacity-30 disabled:cursor-not-allowed"
+                          title="Move up"
+                        >
+                          ▲
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => moveFreeformSection(index, 'down')}
+                          disabled={index === freeformSections.length - 1}
+                          className="p-1 text-gray-400 hover:text-gray-700 disabled:opacity-30 disabled:cursor-not-allowed"
+                          title="Move down"
+                        >
+                          ▼
+                        </button>
                       </div>
                       <button
                         type="button"
@@ -646,7 +817,6 @@ export default function LogPracticePage() {
                   </div>
                 )}
               </div>
-            )}
 
             {/* Notes */}
             <div className="mb-6">

--- a/frontend/src/components/HistoryCard.tsx
+++ b/frontend/src/components/HistoryCard.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState } from 'react'
 import type { PracticeLog } from '@/lib/types'
 import { formatTempo } from '@/lib/metronome'
 
@@ -9,6 +10,7 @@ interface HistoryCardProps {
 }
 
 export default function HistoryCard({ log, dayTitle }: HistoryCardProps) {
+  const [expanded, setExpanded] = useState(false)
   const date = new Date(log.practice_date)
   const formattedDate = date.toLocaleDateString('en-US', {
     weekday: 'long',
@@ -17,56 +19,74 @@ export default function HistoryCard({ log, dayTitle }: HistoryCardProps) {
     day: 'numeric',
   })
 
+  const hasDetails =
+    log.notes || (log.log_details && log.log_details.some((d) => d.content))
+
   return (
-    <div className="bg-white rounded-xl p-6 shadow-md mb-4">
-      <div className="flex justify-between items-center mb-4 pb-4 border-b-2 border-gray-100">
-        <span className="font-semibold text-primary-600 text-lg">{formattedDate}</span>
-        <span className="bg-primary-500 text-white px-4 py-2 rounded-full text-sm">
-          {log.duration_minutes} min
-        </span>
-      </div>
-      {dayTitle && (
-        <p className="font-semibold text-gray-800 mb-2">{dayTitle}</p>
-      )}
-      {log.notes && (
-        <div className="mt-3">
-          <p className="font-semibold text-gray-700">Notes:</p>
-          <p className="text-gray-600">{log.notes}</p>
+    <div
+      className={`bg-white rounded-xl p-6 shadow-md mb-4 ${hasDetails ? 'cursor-pointer hover:shadow-lg transition-shadow' : ''}`}
+      onClick={() => hasDetails && setExpanded(!expanded)}
+    >
+      <div className="flex justify-between items-center">
+        <div className="flex items-center gap-2">
+          <span className="font-semibold text-primary-600 text-lg">{formattedDate}</span>
+          {dayTitle && (
+            <span className="text-gray-500 text-sm">— {dayTitle}</span>
+          )}
         </div>
-      )}
-      {log.log_details && log.log_details.length > 0 && (
-        <div className="mt-3 space-y-2">
-          {log.log_details.map((detail) => (
-            detail.content && (
-              <div key={detail.id}>
-                <p className="font-semibold text-gray-700 capitalize">
-                  {detail.section_type}
-                  {detail.duration_minutes && (
-                    <span className="ml-1 font-normal text-sm text-gray-500">
-                      ({detail.duration_minutes} min)
-                    </span>
-                  )}
-                  :
-                </p>
-                <p className="text-gray-600">{detail.content}</p>
-                {(detail.tempo_practiced || detail.key_practiced || detail.time_signature) && (
-                  <p className="text-sm text-gray-500 mt-0.5">
-                    {[
-                      detail.tempo_practiced && formatTempo(detail.tempo_practiced),
-                      detail.key_practiced,
-                      detail.time_signature,
-                    ]
-                      .filter(Boolean)
-                      .join(' \u00B7 ')}
-                  </p>
-                )}
-              </div>
-            )
-          ))}
+        <div className="flex items-center gap-2">
+          <span className="bg-primary-500 text-white px-4 py-2 rounded-full text-sm">
+            {log.duration_minutes} min
+          </span>
+          {hasDetails && (
+            <span className={`text-gray-400 text-sm inline-block transition-transform ${expanded ? 'rotate-90' : ''}`}>
+              &#x203A;
+            </span>
+          )}
+        </div>
+      </div>
+
+      {expanded && (
+        <div className="mt-4 pt-4 border-t-2 border-gray-100">
+          {log.notes && (
+            <div className="mb-3">
+              <p className="font-semibold text-gray-700">Notes:</p>
+              <p className="text-gray-600">{log.notes}</p>
+            </div>
+          )}
+          {log.log_details && log.log_details.length > 0 && (
+            <div className="space-y-2">
+              {log.log_details.map((detail) => (
+                detail.content && (
+                  <div key={detail.id}>
+                    <p className="font-semibold text-gray-700 capitalize">
+                      {detail.section_type.replace(/-/g, ' ')}
+                      {detail.duration_minutes && (
+                        <span className="ml-1 font-normal text-sm text-gray-500">
+                          ({detail.duration_minutes} min)
+                        </span>
+                      )}
+                      :
+                    </p>
+                    <p className="text-gray-600">{detail.content}</p>
+                    {(detail.tempo_practiced || detail.key_practiced || detail.time_signature) && (
+                      <p className="text-sm text-gray-500 mt-0.5">
+                        {[
+                          detail.tempo_practiced && formatTempo(detail.tempo_practiced),
+                          detail.key_practiced,
+                          detail.time_signature,
+                        ]
+                          .filter(Boolean)
+                          .join(' \u00B7 ')}
+                      </p>
+                    )}
+                  </div>
+                )
+              ))}
+            </div>
+          )}
         </div>
       )}
     </div>
   )
 }
-
-

--- a/frontend/src/components/SectionDetailFields.tsx
+++ b/frontend/src/components/SectionDetailFields.tsx
@@ -57,7 +57,7 @@ export default function SectionDetailFields({
         <label className="text-xs text-gray-500 mr-1">BPM</label>
         <button
           type="button"
-          onClick={() => onTempoChange(prevTempo(tempo ?? 80))}
+          onClick={() => onTempoChange(prevTempo(tempo ?? 72))}
           className="w-7 h-7 flex items-center justify-center rounded border border-gray-300 text-gray-600 hover:bg-gray-100 text-sm"
         >
           -
@@ -68,14 +68,14 @@ export default function SectionDetailFields({
           onChange={(e) =>
             onTempoChange(e.target.value ? parseInt(e.target.value) : undefined)
           }
-          placeholder="--"
+          placeholder="72"
           min="20"
           max="300"
-          className="w-16 px-2 py-1 border-2 border-gray-200 rounded-lg focus:border-primary-500 focus:outline-none text-sm text-center"
+          className="w-16 px-2 py-1 border-2 border-gray-200 rounded-lg focus:border-primary-500 focus:outline-none text-sm text-center [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
         />
         <button
           type="button"
-          onClick={() => onTempoChange(nextTempo(tempo ?? 80))}
+          onClick={() => onTempoChange(nextTempo(tempo ?? 72))}
           className="w-7 h-7 flex items-center justify-center rounded border border-gray-300 text-gray-600 hover:bg-gray-100 text-sm"
         >
           +
@@ -101,7 +101,7 @@ export default function SectionDetailFields({
 
       {/* Time signature */}
       <div className="flex items-center gap-1">
-        <label className="text-xs text-gray-500 mr-1">Time</label>
+        <label className="text-xs text-gray-500 mr-1">Meter</label>
         <select
           value={timeSignature ?? ''}
           onChange={(e) => onTimeSignatureChange(e.target.value || undefined)}


### PR DESCRIPTION
Freeform sections now render in both modes — labeled "Additional sections" in template mode. Template blocks can be skipped via a dismiss button. Freeform section details are merged into the template-mode submit payload. Includes related backend and frontend changes for section detail fields, history display, and analytics.