### PR TITLE
Add user settings infrastructure with suggestions toggle (#55)

### DIFF
--- a/backend/alembic/versions/d36fa4148cc4_add_user_settings_table.py
+++ b/backend/alembic/versions/d36fa4148cc4_add_user_settings_table.py
@@ -1,0 +1,36 @@
+"""add_user_settings_table
+
+Revision ID: d36fa4148cc4
+Revises: f5a6b7c8d9e0
+Create Date: 2026-03-03 13:30:48.389273
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd36fa4148cc4'
+down_revision = 'f5a6b7c8d9e0'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table('user_settings',
+    sa.Column('id', sa.Integer(), nullable=False),
+    sa.Column('user_id', sa.Integer(), nullable=False),
+    sa.Column('suggestions_enabled', sa.Boolean(), nullable=False),
+    sa.Column('created_at', sa.DateTime(), nullable=False),
+    sa.Column('updated_at', sa.DateTime(), nullable=True),
+    sa.ForeignKeyConstraint(['user_id'], ['users.id'], ),
+    sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_user_settings_user_id'), 'user_settings', ['user_id'], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_user_settings_user_id'), table_name='user_settings')
+    op.drop_table('user_settings')
+
+

--- a/backend/app/api/settings.py
+++ b/backend/app/api/settings.py
@@ -1,0 +1,57 @@
+"""
+User Settings API endpoints
+"""
+from fastapi import APIRouter, Depends
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.database import get_session
+from app.models import User, UserSettings, UserSettingsRead, UserSettingsUpdate
+from app.auth import get_current_user
+
+router = APIRouter(prefix="/settings", tags=["settings"])
+
+
+async def _get_or_create_settings(session: AsyncSession, user_id: int) -> UserSettings:
+    """Fetch user's settings row, creating one with defaults if it doesn't exist."""
+    result = await session.exec(
+        select(UserSettings).where(UserSettings.user_id == user_id)
+    )
+    settings = result.first()
+    if settings:
+        return settings
+
+    settings = UserSettings(user_id=user_id)
+    session.add(settings)
+    await session.commit()
+    await session.refresh(settings)
+    return settings
+
+
+@router.get("/", response_model=UserSettingsRead)
+async def get_settings(
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    """Get the current user's settings (auto-creates defaults if none exist)."""
+    settings = await _get_or_create_settings(session, current_user.id)
+    return settings
+
+
+@router.patch("/", response_model=UserSettingsRead)
+async def update_settings(
+    data: UserSettingsUpdate,
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    """Partially update the current user's settings."""
+    settings = await _get_or_create_settings(session, current_user.id)
+
+    update_data = data.model_dump(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(settings, key, value)
+
+    session.add(settings)
+    await session.commit()
+    await session.refresh(settings)
+    return settings

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,7 @@ from sqlalchemy import text
 from app.config import get_settings
 from app.database import engine
 from app.api import instruments, templates, logs, analytics, user, block_types, suggestions, user_instruments
+from app.api import settings as settings_api
 
 settings = get_settings()
 
@@ -56,6 +57,7 @@ app.include_router(user.router, prefix="/api")
 app.include_router(block_types.router, prefix="/api")
 app.include_router(suggestions.router, prefix="/api")
 app.include_router(user_instruments.router, prefix="/api")
+app.include_router(settings_api.router, prefix="/api")
 
 
 @app.get("/")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -52,6 +52,17 @@ class User(SQLModel, table=True):
     practice_templates: List["PracticeTemplate"] = Relationship(back_populates="user")
 
 
+class UserSettings(SQLModel, table=True):
+    """Per-user settings (auto-created on first access)"""
+    __tablename__ = "user_settings"  # type: ignore[assignment]
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="users.id", unique=True, index=True)
+    suggestions_enabled: bool = Field(default=True)
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: Optional[datetime] = Field(default=None, sa_column_kwargs={"onupdate": datetime.utcnow})
+
+
 class Instrument(SQLModel, table=True):
     """Musical instrument (canonical definitions)"""
     __tablename__ = "instruments"  # type: ignore[assignment]
@@ -388,4 +399,16 @@ class AnalyticsSummary(SQLModel):
     total_minutes: int
     average_duration: float
     sessions_by_day: dict = {}
+
+
+class UserSettingsRead(SQLModel):
+    """Response schema for user settings"""
+    model_config = {"from_attributes": True}
+
+    suggestions_enabled: bool
+
+
+class UserSettingsUpdate(SQLModel):
+    """Schema for partial-updating user settings"""
+    suggestions_enabled: Optional[bool] = None
 

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+import { useEffect, useState, useRef } from 'react'
+import { useRouter } from 'next/navigation'
+import { useApi } from '@/lib/useApi'
+import { useUser } from '@clerk/nextjs'
+import type { UserSettings } from '@/lib/types'
+
+export default function SettingsPage() {
+  const [settings, setSettings] = useState<UserSettings | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+  const router = useRouter()
+  const api = useApi()
+  const { isLoaded, isSignedIn } = useUser()
+  const hasFetched = useRef(false)
+
+  useEffect(() => {
+    if (!isLoaded) return
+    if (!isSignedIn) {
+      router.push('/sign-in')
+      return
+    }
+    if (hasFetched.current) return
+    hasFetched.current = true
+
+    const fetchSettings = async () => {
+      try {
+        const data = await api.getSettings()
+        setSettings(data)
+      } catch (err: any) {
+        setError(err.message)
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchSettings()
+  }, [isLoaded, isSignedIn, router, api])
+
+  const handleToggle = async (field: keyof UserSettings, value: boolean) => {
+    if (!settings) return
+    setSaving(true)
+
+    // Optimistic update
+    const prev = settings
+    setSettings({ ...settings, [field]: value })
+
+    try {
+      const updated = await api.updateSettings({ [field]: value })
+      setSettings(updated)
+    } catch (err: any) {
+      // Revert on error
+      setSettings(prev)
+      setError(err.message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (!isLoaded || loading) {
+    return (
+      <main className="min-h-screen bg-gradient-to-br from-primary-100 to-secondary-100 p-8">
+        <div className="max-w-2xl mx-auto">
+          <h1 className="text-4xl font-bold mb-8 text-primary-700">Settings</h1>
+          <div className="bg-white rounded-xl shadow-xl p-8">
+            <p className="text-center text-gray-500">Loading...</p>
+          </div>
+        </div>
+      </main>
+    )
+  }
+
+  if (error) {
+    return (
+      <main className="min-h-screen bg-gradient-to-br from-primary-100 to-secondary-100 p-8">
+        <div className="max-w-2xl mx-auto">
+          <h1 className="text-4xl font-bold mb-8 text-primary-700">Settings</h1>
+          <div className="bg-red-50 rounded-xl shadow-xl p-8">
+            <p className="text-center text-red-600">Error: {error}</p>
+          </div>
+        </div>
+      </main>
+    )
+  }
+
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-primary-100 to-secondary-100 p-8">
+      <div className="max-w-2xl mx-auto">
+        <h1 className="text-4xl font-bold mb-8 text-primary-700">Settings</h1>
+
+        <div className="bg-white rounded-xl shadow-xl p-6 space-y-6">
+          {/* Practice Suggestions */}
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-lg font-semibold text-gray-800">Practice suggestions</h2>
+              <p className="text-sm text-gray-500">
+                Show personalized practice suggestions based on your progress
+              </p>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={settings?.suggestions_enabled}
+              disabled={saving}
+              onClick={() => handleToggle('suggestions_enabled', !settings?.suggestions_enabled)}
+              className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 disabled:opacity-50 ${
+                settings?.suggestions_enabled ? 'bg-primary-600' : 'bg-gray-200'
+              }`}
+            >
+              <span
+                className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                  settings?.suggestions_enabled ? 'translate-x-5' : 'translate-x-0'
+                }`}
+              />
+            </button>
+          </div>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -118,7 +118,19 @@ export default function Header() {
           {/* Desktop User Button */}
           <div className="hidden sm:flex items-center gap-4 flex-shrink-0">
             {isSignedIn ? (
-              <UserButton afterSignOutUrl="/" />
+              <>
+                <Link
+                  href="/settings"
+                  className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-md transition-colors"
+                  title="Settings"
+                >
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                  </svg>
+                </Link>
+                <UserButton afterSignOutUrl="/" />
+              </>
             ) : (
               <Link
                 href="/sign-in"
@@ -132,7 +144,14 @@ export default function Header() {
 
         {/* Mobile Menu Dropdown */}
         {mobileMenuOpen && isSignedIn && (
-          <div className="sm:hidden border-t border-gray-200 py-4">
+          <div className="sm:hidden border-t border-gray-200 py-4 space-y-3">
+            <Link
+              href="/settings"
+              onClick={() => setMobileMenuOpen(false)}
+              className="block text-sm text-gray-600 hover:text-indigo-600 transition-colors"
+            >
+              Settings
+            </Link>
             <div className="flex items-center justify-between">
               <span className="text-sm text-gray-600">Account</span>
               <UserButton afterSignOutUrl="/" />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -19,6 +19,8 @@ import type {
   Exercise,
   SuggestionsProgressResponse,
   SuggestionAction,
+  UserSettings,
+  UserSettingsUpdate,
 } from './types'
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
@@ -243,5 +245,15 @@ export function createAuthenticatedAPI(getToken: () => Promise<string | null>) {
           body: JSON.stringify(action),
         }
       ),
+
+    // Settings
+    getSettings: () =>
+      authFetchAPI<UserSettings>('/api/settings/'),
+
+    updateSettings: (data: UserSettingsUpdate) =>
+      authFetchAPI<UserSettings>('/api/settings/', {
+        method: 'PATCH',
+        body: JSON.stringify(data),
+      }),
   }
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -194,6 +194,15 @@ export interface SuggestionsProgressResponse {
   progress: ExerciseProgress[]
 }
 
+// User settings
+export interface UserSettings {
+  suggestions_enabled: boolean
+}
+
+export interface UserSettingsUpdate {
+  suggestions_enabled?: boolean
+}
+
 // Suggestion types for rules engine
 export type SuggestionType =
   | 'tempo_increase'


### PR DESCRIPTION
Adds a general-purpose user settings system starting with a suggestions_enabled toggle. Includes user_settings table, GET/PATCH API endpoints with auto-created defaults, a frontend settings page with immediate-save toggle, and gear icon in the header.