### PR TITLE
Add suggestion interaction tracking (#57)

### DIFF
--- a/backend/alembic/versions/e7b3c9d1f2a4_add_suggestion_interactions_table.py
+++ b/backend/alembic/versions/e7b3c9d1f2a4_add_suggestion_interactions_table.py
@@ -1,0 +1,41 @@
+"""add_suggestion_interactions_table
+
+Revision ID: e7b3c9d1f2a4
+Revises: d36fa4148cc4
+Create Date: 2026-03-09 10:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'e7b3c9d1f2a4'
+down_revision = 'd36fa4148cc4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'suggestion_interactions',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('instrument_id', sa.Integer(), nullable=True),
+        sa.Column('suggestion_rule_id', sa.String(length=100), nullable=False),
+        sa.Column('suggestion_text', sa.Text(), nullable=False),
+        sa.Column('interaction_type', sa.String(length=20), nullable=False),
+        sa.Column('metadata_json', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.PrimaryKeyConstraint('id'),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id']),
+        sa.ForeignKeyConstraint(['instrument_id'], ['instruments.id']),
+    )
+    op.create_index(op.f('ix_suggestion_interactions_user_id'), 'suggestion_interactions', ['user_id'])
+    op.create_index(op.f('ix_suggestion_interactions_created_at'), 'suggestion_interactions', ['created_at'])
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_suggestion_interactions_created_at'), table_name='suggestion_interactions')
+    op.drop_index(op.f('ix_suggestion_interactions_user_id'), table_name='suggestion_interactions')
+    op.drop_table('suggestion_interactions')

--- a/backend/app/api/suggestions.py
+++ b/backend/app/api/suggestions.py
@@ -15,7 +15,9 @@ from sqlalchemy.orm import selectinload
 from app.database import get_session
 from app.models import (
     ExerciseProgress, Exercise, ExerciseBlock, PracticeDay,
-    PracticeTemplate, Instrument, User, UserSettings
+    PracticeTemplate, Instrument, User, UserSettings,
+    SuggestionInteraction, SuggestionInteractionCreate,
+    SuggestionInteractionRead, InteractionType,
 )
 from app.auth import get_current_user
 from app.suggestions import evaluate_session_rules, SessionSuggestion
@@ -47,6 +49,37 @@ async def get_session_suggestions(
     return await evaluate_session_rules(
         session, current_user.id, instrument_id
     )
+
+
+@router.post("/interactions", response_model=SuggestionInteractionRead, status_code=201)
+async def record_suggestion_interaction(
+    interaction_data: SuggestionInteractionCreate,
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    """
+    Record a user interaction with a suggestion (shown, dismissed, or acted_on).
+    """
+    # Validate interaction_type
+    valid_types = [t.value for t in InteractionType]
+    if interaction_data.interaction_type not in valid_types:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid interaction_type. Must be one of: {valid_types}",
+        )
+
+    interaction = SuggestionInteraction(
+        user_id=current_user.id,
+        instrument_id=interaction_data.instrument_id,
+        suggestion_rule_id=interaction_data.suggestion_rule_id,
+        suggestion_text=interaction_data.suggestion_text,
+        interaction_type=interaction_data.interaction_type,
+        metadata_json=interaction_data.metadata_json,
+    )
+    session.add(interaction)
+    await session.commit()
+    await session.refresh(interaction)
+    return interaction
 
 
 @router.get("/progress")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -33,6 +33,13 @@ class PracticeOutcome(str, Enum):
     NAILED_IT = "nailed_it"
 
 
+class InteractionType(str, Enum):
+    """Type of user interaction with a suggestion"""
+    SHOWN = "shown"
+    DISMISSED = "dismissed"
+    ACTED_ON = "acted_on"
+
+
 class User(SQLModel, table=True):
     """User account (authenticated via Clerk)"""
     __tablename__ = "users"  # type: ignore[assignment]
@@ -61,6 +68,41 @@ class UserSettings(SQLModel, table=True):
     suggestions_enabled: bool = Field(default=True)
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: Optional[datetime] = Field(default=None, sa_column_kwargs={"onupdate": datetime.utcnow})
+
+
+class SuggestionInteraction(SQLModel, table=True):
+    """Tracks user interactions with practice suggestions"""
+    __tablename__ = "suggestion_interactions"  # type: ignore[assignment]
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="users.id", index=True)
+    instrument_id: Optional[int] = Field(default=None, foreign_key="instruments.id")
+    suggestion_rule_id: str = Field(max_length=100)
+    suggestion_text: str
+    interaction_type: str = Field(max_length=20)  # Stores InteractionType value
+    metadata_json: Optional[str] = Field(default=None)  # JSON string for extensibility
+    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+
+
+class SuggestionInteractionCreate(SQLModel):
+    """Schema for recording a suggestion interaction"""
+    suggestion_rule_id: str
+    suggestion_text: str
+    interaction_type: str  # One of InteractionType values
+    instrument_id: Optional[int] = None
+    metadata_json: Optional[str] = None
+
+
+class SuggestionInteractionRead(SQLModel):
+    """Response schema for suggestion interactions"""
+    model_config = {"from_attributes": True}
+
+    id: int
+    suggestion_rule_id: str
+    suggestion_text: str
+    interaction_type: str
+    instrument_id: Optional[int] = None
+    created_at: datetime
 
 
 class Instrument(SQLModel, table=True):

--- a/backend/tests/test_suggestions.py
+++ b/backend/tests/test_suggestions.py
@@ -34,6 +34,87 @@ class TestGetProgress:
         assert resp.status_code == 401
 
 
+class TestRecordInteraction:
+    async def test_record_shown(self, client: AsyncClient):
+        resp = await client.post(
+            "/api/suggestions/interactions",
+            json={
+                "suggestion_rule_id": "consistency",
+                "suggestion_text": "It's been 5 days since your last practice.",
+                "interaction_type": "shown",
+            },
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["suggestion_rule_id"] == "consistency"
+        assert data["interaction_type"] == "shown"
+        assert "id" in data
+        assert "created_at" in data
+
+    async def test_record_dismissed(self, client: AsyncClient):
+        resp = await client.post(
+            "/api/suggestions/interactions",
+            json={
+                "suggestion_rule_id": "balance",
+                "suggestion_text": "Try balancing your practice more.",
+                "interaction_type": "dismissed",
+                "instrument_id": None,
+            },
+        )
+        assert resp.status_code == 201
+        assert resp.json()["interaction_type"] == "dismissed"
+
+    async def test_record_acted_on(self, client: AsyncClient):
+        resp = await client.post(
+            "/api/suggestions/interactions",
+            json={
+                "suggestion_rule_id": "warmup",
+                "suggestion_text": "Consider adding a warm-up.",
+                "interaction_type": "acted_on",
+            },
+        )
+        assert resp.status_code == 201
+        assert resp.json()["interaction_type"] == "acted_on"
+
+    async def test_with_instrument_id(
+        self, client: AsyncClient, test_instrument,
+    ):
+        resp = await client.post(
+            "/api/suggestions/interactions",
+            json={
+                "suggestion_rule_id": "duration",
+                "suggestion_text": "Your sessions are getting shorter.",
+                "interaction_type": "shown",
+                "instrument_id": test_instrument.id,
+            },
+        )
+        assert resp.status_code == 201
+        assert resp.json()["instrument_id"] == test_instrument.id
+
+    async def test_invalid_interaction_type(self, client: AsyncClient):
+        resp = await client.post(
+            "/api/suggestions/interactions",
+            json={
+                "suggestion_rule_id": "consistency",
+                "suggestion_text": "Test",
+                "interaction_type": "invalid_type",
+            },
+        )
+        assert resp.status_code == 400
+        assert "interaction_type" in resp.json()["detail"]
+
+    async def test_requires_auth(self, unauth_client: AsyncClient):
+        resp = await unauth_client.post(
+            "/api/suggestions/interactions",
+            json={
+                "suggestion_rule_id": "consistency",
+                "suggestion_text": "Test",
+                "interaction_type": "shown",
+            },
+        )
+        assert resp.status_code == 401
+
+
 class TestDismissSuggestion:
     async def test_dismiss_returns_success(self, client: AsyncClient):
         resp = await client.post("/api/suggestions/dismiss/some_key")


### PR DESCRIPTION
## Summary
- Add `suggestion_interactions` table to track when suggestions are shown, dismissed, or acted on
- Add `POST /api/suggestions/interactions` endpoint for recording interactions
- Add Alembic migration with indexes on `user_id` and `created_at` for efficient querying
- Schema includes `metadata_json` field for future extensibility (e.g., what action was taken, context)

## Test plan
- [x] All 6 new interaction tests pass (shown, dismissed, acted_on, with instrument, invalid type, auth)
- [x] Full backend suite passes (129 tests)
- [ ] Verify migration runs cleanly against dev database

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)