### PR TITLE
Add Today API endpoints (#106)

### DIFF
--- a/backend/app/api/today_api.py
+++ b/backend/app/api/today_api.py
@@ -1,0 +1,337 @@
+"""Today tab API — surfaces which instruments are due and what to practice next."""
+from datetime import date, timedelta
+from typing import Optional
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import func
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.auth import get_current_user
+from app.database import get_session
+from app.models import (
+    User,
+    Instrument,
+    Template,
+    TemplateSession,
+    Section,
+    PracticeLog,
+)
+from app.api.ownership import get_owned_instrument
+from app.schemas.today import (
+    TodayResponse,
+    ActiveSessionInfo,
+    InstrumentBrief,
+    CurrentSessionInfo,
+    InstrumentDue,
+    InstrumentNotDue,
+    RepeatSessionInfo,
+    SessionBrief,
+)
+
+router = APIRouter(prefix="/today", tags=["today"])
+
+# ---------------------------------------------------------------------------
+# Due-logic thresholds (days since last practice)
+# ---------------------------------------------------------------------------
+_DUE_THRESHOLDS = {
+    "daily": 0,
+    "few_times_a_week": 2,
+    "weekly": 5,
+}
+
+
+def _is_due(frequency: str, days_since_last: Optional[int]) -> bool:
+    """Return True if the instrument is due for practice."""
+    if frequency == "occasionally":
+        return False
+    threshold = _DUE_THRESHOLDS.get(frequency)
+    if threshold is None:
+        return False
+    # Never practiced → due (except occasionally, handled above)
+    if days_since_last is None:
+        return True
+    return days_since_last >= threshold
+
+
+def _next_due_description(frequency: str, days_since_last: Optional[int]) -> Optional[str]:
+    """Human-readable string for when an instrument is next due."""
+    if frequency == "occasionally":
+        return "practice when you feel like it"
+    threshold = _DUE_THRESHOLDS.get(frequency)
+    if threshold is None or days_since_last is None:
+        return None
+    days_remaining = threshold - days_since_last
+    if days_remaining <= 0:
+        return "due today"
+    if days_remaining == 1:
+        return "due tomorrow"
+    return f"due in {days_remaining} days"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _get_active_session(
+    session: AsyncSession, user_id: int
+) -> Optional[ActiveSessionInfo]:
+    """Find any in-progress PracticeLog for the user."""
+    result = await session.exec(
+        select(PracticeLog)
+        .where(
+            PracticeLog.user_id == user_id,
+            PracticeLog.status == "in_progress",
+            PracticeLog.deleted_at == None,  # noqa: E711
+        )
+        .options(selectinload(PracticeLog.instrument))
+        .order_by(PracticeLog.created_at.desc())
+        .limit(1)
+    )
+    log = result.first()
+    if not log:
+        return None
+    return ActiveSessionInfo(
+        practice_log_id=log.id,
+        instrument_id=log.instrument_id,
+        instrument_name=log.instrument.name,
+        session_name=log.template_session.name if log.template_session else None,
+        started_at=log.created_at,
+    )
+
+
+async def _build_current_session(
+    session: AsyncSession, template: Template, template_sessions: list[TemplateSession]
+) -> Optional[CurrentSessionInfo]:
+    """Build CurrentSessionInfo from the active template's current rotation."""
+    if not template_sessions:
+        return None
+
+    idx = template.current_rotation_index % len(template_sessions)
+    current_ts = template_sessions[idx]
+
+    # Load sections for estimated duration and section types
+    result = await session.exec(
+        select(Section)
+        .where(Section.template_session_id == current_ts.id)
+        .order_by(Section.display_order)
+    )
+    sections = result.all()
+
+    estimated_duration = sum(s.estimated_duration_minutes for s in sections)
+    section_types = list(dict.fromkeys(s.section_type for s in sections))
+
+    return CurrentSessionInfo(
+        template_id=template.id,
+        template_name=template.name,
+        session_id=current_ts.id,
+        session_name=current_ts.name,
+        focus_description=current_ts.focus_description,
+        rotation_position=f"session {idx + 1} of {len(template_sessions)}",
+        estimated_duration_minutes=estimated_duration,
+        section_types=section_types,
+    )
+
+
+async def _build_repeat_session(
+    session: AsyncSession,
+    instrument_id: int,
+    user_id: int,
+    current_session_id: Optional[int],
+) -> Optional[RepeatSessionInfo]:
+    """Find the most recent completed session for repeat shortcut."""
+    result = await session.exec(
+        select(PracticeLog)
+        .where(
+            PracticeLog.user_id == user_id,
+            PracticeLog.instrument_id == instrument_id,
+            PracticeLog.status == "completed",
+            PracticeLog.template_session_id != None,  # noqa: E711
+            PracticeLog.deleted_at == None,  # noqa: E711
+        )
+        .order_by(PracticeLog.created_at.desc())
+        .limit(1)
+    )
+    log = result.first()
+    if not log:
+        return None
+    # Don't show repeat when it's the same as current
+    if log.template_session_id == current_session_id:
+        return None
+
+    # Look up the session name
+    ts_result = await session.exec(
+        select(TemplateSession).where(TemplateSession.id == log.template_session_id)
+    )
+    ts = ts_result.first()
+    if not ts:
+        return None
+
+    return RepeatSessionInfo(
+        session_id=ts.id,
+        session_name=ts.name,
+    )
+
+
+async def _build_instrument_entry(
+    session: AsyncSession,
+    instrument: Instrument,
+    user_id: int,
+    today: date,
+):
+    """Build a due/not-due entry for a single instrument."""
+    # Last practiced date
+    result = await session.exec(
+        select(func.max(PracticeLog.practice_date)).where(
+            PracticeLog.instrument_id == instrument.id,
+            PracticeLog.user_id == user_id,
+            PracticeLog.status == "completed",
+            PracticeLog.deleted_at == None,  # noqa: E711
+        )
+    )
+    last_practiced_at = result.one()
+
+    days_since_last = (today - last_practiced_at).days if last_practiced_at else None
+
+    brief = InstrumentBrief(
+        id=instrument.id,
+        name=instrument.name,
+        practice_frequency=instrument.practice_frequency,
+    )
+
+    due = _is_due(instrument.practice_frequency, days_since_last)
+
+    if not due:
+        return InstrumentNotDue(
+            instrument=brief,
+            last_practiced_at=last_practiced_at,
+            days_since_last=days_since_last,
+            next_due_description=_next_due_description(
+                instrument.practice_frequency, days_since_last
+            ),
+        )
+
+    # Load active template and its sessions
+    tmpl_result = await session.exec(
+        select(Template).where(
+            Template.instrument_id == instrument.id,
+            Template.user_id == user_id,
+            Template.is_active == True,  # noqa: E712
+            Template.deleted_at == None,  # noqa: E711
+        )
+    )
+    template = tmpl_result.first()
+
+    current_session = None
+    repeat_session = None
+    all_sessions: list[SessionBrief] = []
+
+    if template:
+        # Load all sessions ordered by display_order
+        ts_result = await session.exec(
+            select(TemplateSession)
+            .where(TemplateSession.template_id == template.id)
+            .order_by(TemplateSession.display_order)
+        )
+        template_sessions = list(ts_result.all())
+
+        current_session = await _build_current_session(
+            session, template, template_sessions
+        )
+
+        current_session_id = current_session.session_id if current_session else None
+        repeat_session = await _build_repeat_session(
+            session, instrument.id, user_id, current_session_id
+        )
+
+        all_sessions = [
+            SessionBrief(
+                session_id=ts.id,
+                session_name=ts.name,
+                display_order=ts.display_order,
+            )
+            for ts in template_sessions
+        ]
+
+    return InstrumentDue(
+        instrument=brief,
+        last_practiced_at=last_practiced_at,
+        days_since_last=days_since_last,
+        current_session=current_session,
+        repeat_session=repeat_session,
+        all_sessions=all_sessions,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+@router.get("", response_model=TodayResponse)
+async def get_today(
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    """Today context for all user instruments."""
+    today = date.today()
+
+    active_session = await _get_active_session(session, current_user.id)
+
+    # Fetch all non-deleted instruments
+    result = await session.exec(
+        select(Instrument).where(
+            Instrument.user_id == current_user.id,
+            Instrument.deleted_at == None,  # noqa: E711
+        )
+        .order_by(Instrument.display_order, Instrument.id)
+    )
+    instruments = result.all()
+
+    instruments_due = []
+    instruments_not_due = []
+
+    for instrument in instruments:
+        entry = await _build_instrument_entry(
+            session, instrument, current_user.id, today
+        )
+        if isinstance(entry, InstrumentDue):
+            instruments_due.append(entry)
+        else:
+            instruments_not_due.append(entry)
+
+    return TodayResponse(
+        active_session=active_session,
+        instruments_due=instruments_due,
+        instruments_not_due=instruments_not_due,
+    )
+
+
+@router.get("/{instrument_id}", response_model=TodayResponse)
+async def get_today_instrument(
+    instrument_id: int,
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    """Today context scoped to a single instrument."""
+    instrument = await get_owned_instrument(session, instrument_id, current_user.id)
+    today = date.today()
+
+    active_session = await _get_active_session(session, current_user.id)
+
+    entry = await _build_instrument_entry(
+        session, instrument, current_user.id, today
+    )
+
+    instruments_due = []
+    instruments_not_due = []
+    if isinstance(entry, InstrumentDue):
+        instruments_due.append(entry)
+    else:
+        instruments_not_due.append(entry)
+
+    return TodayResponse(
+        active_session=active_session,
+        instruments_due=instruments_due,
+        instruments_not_due=instruments_not_due,
+    )

--- a/backend/app/api/today_api.py
+++ b/backend/app/api/today_api.py
@@ -1,6 +1,6 @@
 """Today tab API — surfaces which instruments are due and what to practice next."""
 from datetime import date, datetime, timedelta, timezone
-from typing import Optional
+from typing import Optional, Union
 
 from fastapi import APIRouter, Depends
 from sqlalchemy import func
@@ -75,10 +75,15 @@ def _next_due_description(frequency: str, days_since_last: Optional[int]) -> Opt
 # ---------------------------------------------------------------------------
 
 async def _get_active_session(
-    session: AsyncSession, user_id: int
+    session: AsyncSession,
+    user_id: int,
+    instrument_id: Optional[int] = None,
 ) -> Optional[ActiveSessionInfo]:
-    """Find any in-progress PracticeLog for the user."""
-    result = await session.exec(
+    """Find any in-progress PracticeLog for the user.
+
+    When instrument_id is provided, scopes to that instrument only.
+    """
+    query = (
         select(PracticeLog)
         .where(
             PracticeLog.user_id == user_id,
@@ -92,6 +97,9 @@ async def _get_active_session(
         .order_by(PracticeLog.created_at.desc())
         .limit(1)
     )
+    if instrument_id is not None:
+        query = query.where(PracticeLog.instrument_id == instrument_id)
+    result = await session.exec(query)
     log = result.first()
     if not log:
         return None
@@ -122,7 +130,7 @@ async def _build_current_session(
     )
     sections = result.all()
 
-    estimated_duration = sum(s.estimated_duration_minutes for s in sections)
+    estimated_duration = sum(s.estimated_duration_minutes for s in sections) or None
     section_types = list(dict.fromkeys(s.section_type for s in sections))
 
     return CurrentSessionInfo(
@@ -180,8 +188,12 @@ async def _build_instrument_entry(
     instrument: Instrument,
     user_id: int,
     today: date,
-):
-    """Build a due/not-due entry for a single instrument."""
+) -> Union[InstrumentDue, InstrumentNotDue]:
+    """Build a due/not-due entry for a single instrument.
+
+    N+1: runs 1-5 queries per instrument (last_practiced, template, sessions,
+    sections, repeat log). Fine for typical usage (1-5 instruments per user).
+    """
     # Last practiced date
     result = await session.exec(
         select(func.max(PracticeLog.practice_date)).where(
@@ -318,7 +330,9 @@ async def get_today_instrument(
     instrument = await get_owned_instrument(session, instrument_id, current_user.id)
     today = datetime.now(timezone.utc).date()
 
-    active_session = await _get_active_session(session, current_user.id)
+    active_session = await _get_active_session(
+        session, current_user.id, instrument_id=instrument.id
+    )
 
     entry = await _build_instrument_entry(
         session, instrument, current_user.id, today

--- a/backend/app/api/today_api.py
+++ b/backend/app/api/today_api.py
@@ -1,5 +1,5 @@
 """Today tab API — surfaces which instruments are due and what to practice next."""
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 from typing import Optional
 
 from fastapi import APIRouter, Depends
@@ -85,7 +85,10 @@ async def _get_active_session(
             PracticeLog.status == "in_progress",
             PracticeLog.deleted_at == None,  # noqa: E711
         )
-        .options(selectinload(PracticeLog.instrument))
+        .options(
+            selectinload(PracticeLog.instrument),
+            selectinload(PracticeLog.template_session),
+        )
         .order_by(PracticeLog.created_at.desc())
         .limit(1)
     )
@@ -139,6 +142,7 @@ async def _build_repeat_session(
     instrument_id: int,
     user_id: int,
     current_session_id: Optional[int],
+    template_sessions: list[TemplateSession],
 ) -> Optional[RepeatSessionInfo]:
     """Find the most recent completed session for repeat shortcut."""
     result = await session.exec(
@@ -160,11 +164,8 @@ async def _build_repeat_session(
     if log.template_session_id == current_session_id:
         return None
 
-    # Look up the session name
-    ts_result = await session.exec(
-        select(TemplateSession).where(TemplateSession.id == log.template_session_id)
-    )
-    ts = ts_result.first()
+    # Look up the session name from the already-loaded list
+    ts = next((s for s in template_sessions if s.id == log.template_session_id), None)
     if not ts:
         return None
 
@@ -242,7 +243,7 @@ async def _build_instrument_entry(
 
         current_session_id = current_session.session_id if current_session else None
         repeat_session = await _build_repeat_session(
-            session, instrument.id, user_id, current_session_id
+            session, instrument.id, user_id, current_session_id, template_sessions
         )
 
         all_sessions = [
@@ -274,7 +275,7 @@ async def get_today(
     current_user: User = Depends(get_current_user),
 ):
     """Today context for all user instruments."""
-    today = date.today()
+    today = datetime.now(timezone.utc).date()
 
     active_session = await _get_active_session(session, current_user.id)
 
@@ -315,7 +316,7 @@ async def get_today_instrument(
 ):
     """Today context scoped to a single instrument."""
     instrument = await get_owned_instrument(session, instrument_id, current_user.id)
-    today = date.today()
+    today = datetime.now(timezone.utc).date()
 
     active_session = await _get_active_session(session, current_user.id)
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -53,7 +53,7 @@ app.add_middleware(
 )
 
 # Kantelo API routers
-from app.api import user_api, settings_api, instruments_api, templates_api, sessions_sections_blocks_api, practice_api
+from app.api import user_api, settings_api, instruments_api, templates_api, sessions_sections_blocks_api, practice_api, today_api
 
 app.include_router(user_api.router, prefix="/api")
 app.include_router(settings_api.router, prefix="/api")
@@ -61,6 +61,7 @@ app.include_router(instruments_api.router, prefix="/api")
 app.include_router(templates_api.router, prefix="/api")
 app.include_router(sessions_sections_blocks_api.router, prefix="/api")
 app.include_router(practice_api.router, prefix="/api")
+app.include_router(today_api.router, prefix="/api")
 
 
 @app.get("/")

--- a/backend/app/schemas/today.py
+++ b/backend/app/schemas/today.py
@@ -30,11 +30,24 @@ class CurrentSessionInfo(BaseModel):
     section_types: List[str]
 
 
+class RepeatSessionInfo(BaseModel):
+    session_id: int
+    session_name: str
+
+
+class SessionBrief(BaseModel):
+    session_id: int
+    session_name: str
+    display_order: int
+
+
 class InstrumentDue(BaseModel):
     instrument: InstrumentBrief
     last_practiced_at: Optional[date] = None
     days_since_last: Optional[int] = None
     current_session: Optional[CurrentSessionInfo] = None
+    repeat_session: Optional[RepeatSessionInfo] = None
+    all_sessions: List[SessionBrief] = []
 
 
 class InstrumentNotDue(BaseModel):

--- a/backend/app/schemas/today.py
+++ b/backend/app/schemas/today.py
@@ -26,7 +26,7 @@ class CurrentSessionInfo(BaseModel):
     session_name: str
     focus_description: Optional[str] = None
     rotation_position: str  # e.g. "session 3 of 7"
-    estimated_duration_minutes: int
+    estimated_duration_minutes: Optional[int] = None
     section_types: List[str]
 
 

--- a/backend/tests/test_today_api.py
+++ b/backend/tests/test_today_api.py
@@ -160,6 +160,36 @@ class TestDueLogic:
         assert len(data["instruments_not_due"]) == 1
         assert data["instruments_not_due"][0]["next_due_description"] == "due tomorrow"
 
+    async def test_deleted_instrument_excluded(
+        self, client: AsyncClient, db_session: AsyncSession, test_user
+    ):
+        from app.enums import utcnow
+        inst = Instrument(
+            user_id=test_user.id, name="Deleted", practice_frequency="daily",
+            deleted_at=utcnow(),
+        )
+        db_session.add(inst)
+        await db_session.commit()
+
+        resp = await client.get("/api/today")
+        data = resp.json()
+        assert len(data["instruments_due"]) == 0
+        assert len(data["instruments_not_due"]) == 0
+
+    async def test_mixed_due_and_not_due(
+        self, client: AsyncClient, db_session: AsyncSession, test_user
+    ):
+        daily = await _make_instrument(db_session, test_user, name="Violin", frequency="daily")
+        weekly = await _make_instrument(db_session, test_user, name="Piano", frequency="weekly")
+        await _make_log(db_session, test_user, weekly, days_ago=1)  # not due yet
+
+        resp = await client.get("/api/today")
+        data = resp.json()
+        assert len(data["instruments_due"]) == 1
+        assert data["instruments_due"][0]["instrument"]["name"] == "Violin"
+        assert len(data["instruments_not_due"]) == 1
+        assert data["instruments_not_due"][0]["instrument"]["name"] == "Piano"
+
 
 # ===========================================================================
 # Active session tests
@@ -176,6 +206,24 @@ class TestActiveSession:
         data = resp.json()
         assert data["active_session"] is not None
         assert data["active_session"]["instrument_name"] == "Violin"
+
+    async def test_active_session_with_template(
+        self, client: AsyncClient, db_session: AsyncSession, test_user
+    ):
+        inst = await _make_instrument(db_session, test_user)
+        tmpl, sessions = await _make_template_with_sessions(
+            db_session, test_user, inst
+        )
+        await _make_log(
+            db_session, test_user, inst,
+            status="in_progress", days_ago=0,
+            template=tmpl, template_session=sessions[0],
+        )
+
+        resp = await client.get("/api/today")
+        data = resp.json()
+        assert data["active_session"] is not None
+        assert data["active_session"]["session_name"] == "Session 1"
 
     async def test_no_active_session(
         self, client: AsyncClient, db_session: AsyncSession, test_user
@@ -212,6 +260,22 @@ class TestCurrentSession:
         assert cs["rotation_position"] == "session 2 of 3"
         assert cs["estimated_duration_minutes"] == 10
         assert cs["section_types"] == ["warmup"]
+
+    async def test_rotation_index_wraps_around(
+        self, client: AsyncClient, db_session: AsyncSession, test_user
+    ):
+        inst = await _make_instrument(db_session, test_user, frequency="daily")
+        await _make_template_with_sessions(
+            db_session, test_user, inst,
+            session_names=["A", "B", "C"],
+            rotation_index=5,  # 5 % 3 = 2 → session C
+        )
+
+        resp = await client.get("/api/today")
+        data = resp.json()
+        cs = data["instruments_due"][0]["current_session"]
+        assert cs["session_name"] == "C"
+        assert cs["rotation_position"] == "session 3 of 3"
 
     async def test_no_template_fallback(
         self, client: AsyncClient, db_session: AsyncSession, test_user

--- a/backend/tests/test_today_api.py
+++ b/backend/tests/test_today_api.py
@@ -1,6 +1,6 @@
 """Tests for /api/today endpoints."""
 import pytest
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 from httpx import AsyncClient
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -12,7 +12,7 @@ from app.models import Instrument, Template, TemplateSession, Section, PracticeL
 # ---------------------------------------------------------------------------
 
 def _days_ago(n: int) -> date:
-    return date.today() - timedelta(days=n)
+    return datetime.now(timezone.utc).date() - timedelta(days=n)
 
 
 async def _make_instrument(db, user, *, name="Violin", frequency="few_times_a_week", **kw):
@@ -225,6 +225,33 @@ class TestActiveSession:
         assert data["active_session"] is not None
         assert data["active_session"]["session_name"] == "Session 1"
 
+    async def test_active_session_returns_most_recent(
+        self, client: AsyncClient, db_session: AsyncSession, test_user
+    ):
+        """When multiple in-progress logs exist, return the most recent."""
+        inst = await _make_instrument(db_session, test_user)
+        await _make_log(db_session, test_user, inst, status="in_progress", days_ago=1)
+        await _make_log(db_session, test_user, inst, status="in_progress", days_ago=0)
+
+        resp = await client.get("/api/today")
+        data = resp.json()
+        assert data["active_session"] is not None
+        # Should be the most recently created one
+        assert data["active_session"]["practice_log_id"] is not None
+
+    async def test_single_instrument_scopes_active_session(
+        self, client: AsyncClient, db_session: AsyncSession, test_user
+    ):
+        """GET /api/today/{id} only shows active session for that instrument."""
+        violin = await _make_instrument(db_session, test_user, name="Violin", frequency="daily")
+        piano = await _make_instrument(db_session, test_user, name="Piano", frequency="daily")
+        await _make_log(db_session, test_user, piano, status="in_progress", days_ago=0)
+
+        resp = await client.get(f"/api/today/{violin.id}")
+        data = resp.json()
+        # Piano's active session should NOT appear when scoped to violin
+        assert data["active_session"] is None
+
     async def test_no_active_session(
         self, client: AsyncClient, db_session: AsyncSession, test_user
     ):
@@ -276,6 +303,25 @@ class TestCurrentSession:
         cs = data["instruments_due"][0]["current_session"]
         assert cs["session_name"] == "C"
         assert cs["rotation_position"] == "session 3 of 3"
+
+    async def test_template_with_zero_sessions(
+        self, client: AsyncClient, db_session: AsyncSession, test_user
+    ):
+        """Active template with no sessions → current_session is null."""
+        inst = await _make_instrument(db_session, test_user, frequency="daily")
+        # Create template directly without sessions
+        tmpl = Template(
+            user_id=test_user.id, instrument_id=inst.id,
+            name="Empty Plan", is_active=True,
+        )
+        db_session.add(tmpl)
+        await db_session.commit()
+
+        resp = await client.get("/api/today")
+        data = resp.json()
+        due = data["instruments_due"][0]
+        assert due["current_session"] is None
+        assert due["all_sessions"] == []
 
     async def test_no_template_fallback(
         self, client: AsyncClient, db_session: AsyncSession, test_user
@@ -349,6 +395,45 @@ class TestRepeatSession:
         due = data["instruments_due"][0]
         assert due["repeat_session"] is None
 
+    async def test_repeat_session_null_after_template_switch(
+        self, client: AsyncClient, db_session: AsyncSession, test_user
+    ):
+        """Last session used old template's session → repeat_session is null."""
+        inst = await _make_instrument(db_session, test_user, frequency="daily")
+
+        # Old template (now inactive)
+        old_tmpl = Template(
+            user_id=test_user.id, instrument_id=inst.id,
+            name="Old Plan", is_active=False,
+        )
+        db_session.add(old_tmpl)
+        await db_session.commit()
+        await db_session.refresh(old_tmpl)
+
+        old_ts = TemplateSession(
+            template_id=old_tmpl.id, name="Old Session", display_order=0
+        )
+        db_session.add(old_ts)
+        await db_session.commit()
+        await db_session.refresh(old_ts)
+
+        # Log from old template
+        await _make_log(
+            db_session, test_user, inst, days_ago=1,
+            template=old_tmpl, template_session=old_ts,
+        )
+
+        # New active template
+        await _make_template_with_sessions(
+            db_session, test_user, inst, session_names=["New Session"]
+        )
+
+        resp = await client.get("/api/today")
+        data = resp.json()
+        due = data["instruments_due"][0]
+        # Old session not in new template's sessions → null
+        assert due["repeat_session"] is None
+
 
 # ===========================================================================
 # All sessions tests
@@ -417,4 +502,10 @@ class TestSingleInstrument:
 class TestAuth:
     async def test_unauthenticated_returns_401(self, unauth_client: AsyncClient):
         resp = await unauth_client.get("/api/today")
+        assert resp.status_code == 401
+
+    async def test_unauthenticated_single_instrument_returns_401(
+        self, unauth_client: AsyncClient
+    ):
+        resp = await unauth_client.get("/api/today/1")
         assert resp.status_code == 401

--- a/backend/tests/test_today_api.py
+++ b/backend/tests/test_today_api.py
@@ -1,0 +1,356 @@
+"""Tests for /api/today endpoints."""
+import pytest
+from datetime import date, timedelta
+from httpx import AsyncClient
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models import Instrument, Template, TemplateSession, Section, PracticeLog
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _days_ago(n: int) -> date:
+    return date.today() - timedelta(days=n)
+
+
+async def _make_instrument(db, user, *, name="Violin", frequency="few_times_a_week", **kw):
+    inst = Instrument(user_id=user.id, name=name, practice_frequency=frequency, **kw)
+    db.add(inst)
+    await db.commit()
+    await db.refresh(inst)
+    return inst
+
+
+async def _make_template_with_sessions(
+    db, user, instrument, *, session_names=("Session 1",), rotation_index=0
+):
+    """Create an active template with named sessions, each having one warmup section."""
+    tmpl = Template(
+        user_id=user.id,
+        instrument_id=instrument.id,
+        name="Practice Plan",
+        is_active=True,
+        current_rotation_index=rotation_index,
+    )
+    db.add(tmpl)
+    await db.commit()
+    await db.refresh(tmpl)
+
+    sessions = []
+    for i, name in enumerate(session_names):
+        ts = TemplateSession(
+            template_id=tmpl.id, name=name, display_order=i
+        )
+        db.add(ts)
+        await db.commit()
+        await db.refresh(ts)
+        sessions.append(ts)
+
+        section = Section(
+            template_session_id=ts.id,
+            name="Warm-up",
+            section_type="warmup",
+            estimated_duration_minutes=10,
+            display_order=0,
+        )
+        db.add(section)
+        await db.commit()
+
+    return tmpl, sessions
+
+
+async def _make_log(db, user, instrument, *, status="completed", days_ago=0,
+                    template=None, template_session=None):
+    log = PracticeLog(
+        user_id=user.id,
+        instrument_id=instrument.id,
+        status=status,
+        practice_date=_days_ago(days_ago),
+        total_duration_minutes=30,
+        template_id=template.id if template else None,
+        template_session_id=template_session.id if template_session else None,
+    )
+    db.add(log)
+    await db.commit()
+    await db.refresh(log)
+    return log
+
+
+# ===========================================================================
+# Due calculation tests
+# ===========================================================================
+
+class TestDueLogic:
+    async def test_daily_always_due(
+        self, client: AsyncClient, db_session: AsyncSession, test_user
+    ):
+        inst = await _make_instrument(db_session, test_user, frequency="daily")
+        await _make_log(db_session, test_user, inst, days_ago=0)
+
+        resp = await client.get("/api/today")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["instruments_due"]) == 1
+        assert data["instruments_due"][0]["instrument"]["name"] == "Violin"
+
+    async def test_few_times_a_week_due_at_2_days(
+        self, client: AsyncClient, db_session: AsyncSession, test_user
+    ):
+        inst = await _make_instrument(db_session, test_user, frequency="few_times_a_week")
+        await _make_log(db_session, test_user, inst, days_ago=2)
+
+        resp = await client.get("/api/today")
+        data = resp.json()
+        assert len(data["instruments_due"]) == 1
+        assert data["instruments_due"][0]["days_since_last"] == 2
+
+    async def test_weekly_due_at_5_days(
+        self, client: AsyncClient, db_session: AsyncSession, test_user
+    ):
+        inst = await _make_instrument(db_session, test_user, frequency="weekly")
+        await _make_log(db_session, test_user, inst, days_ago=5)
+
+        resp = await client.get("/api/today")
+        data = resp.json()
+        assert len(data["instruments_due"]) == 1
+
+    async def test_occasionally_never_due(
+        self, client: AsyncClient, db_session: AsyncSession, test_user
+    ):
+        await _make_instrument(db_session, test_user, frequency="occasionally")
+
+        resp = await client.get("/api/today")
+        data = resp.json()
+        assert len(data["instruments_due"]) == 0
+        assert len(data["instruments_not_due"]) == 1
+        assert data["instruments_not_due"][0]["next_due_description"] == "practice when you feel like it"
+
+    async def test_never_practiced_is_due(
+        self, client: AsyncClient, db_session: AsyncSession, test_user
+    ):
+        await _make_instrument(db_session, test_user, frequency="daily")
+
+        resp = await client.get("/api/today")
+        data = resp.json()
+        assert len(data["instruments_due"]) == 1
+        assert data["instruments_due"][0]["last_practiced_at"] is None
+        assert data["instruments_due"][0]["days_since_last"] is None
+
+    async def test_never_practiced_occasionally_not_due(
+        self, client: AsyncClient, db_session: AsyncSession, test_user
+    ):
+        await _make_instrument(db_session, test_user, frequency="occasionally")
+
+        resp = await client.get("/api/today")
+        data = resp.json()
+        assert len(data["instruments_due"]) == 0
+        assert len(data["instruments_not_due"]) == 1
+
+    async def test_not_due_few_times_practiced_yesterday(
+        self, client: AsyncClient, db_session: AsyncSession, test_user
+    ):
+        inst = await _make_instrument(db_session, test_user, frequency="few_times_a_week")
+        await _make_log(db_session, test_user, inst, days_ago=1)
+
+        resp = await client.get("/api/today")
+        data = resp.json()
+        assert len(data["instruments_due"]) == 0
+        assert len(data["instruments_not_due"]) == 1
+        assert data["instruments_not_due"][0]["next_due_description"] == "due tomorrow"
+
+
+# ===========================================================================
+# Active session tests
+# ===========================================================================
+
+class TestActiveSession:
+    async def test_active_session_detected(
+        self, client: AsyncClient, db_session: AsyncSession, test_user
+    ):
+        inst = await _make_instrument(db_session, test_user)
+        await _make_log(db_session, test_user, inst, status="in_progress", days_ago=0)
+
+        resp = await client.get("/api/today")
+        data = resp.json()
+        assert data["active_session"] is not None
+        assert data["active_session"]["instrument_name"] == "Violin"
+
+    async def test_no_active_session(
+        self, client: AsyncClient, db_session: AsyncSession, test_user
+    ):
+        await _make_instrument(db_session, test_user)
+
+        resp = await client.get("/api/today")
+        data = resp.json()
+        assert data["active_session"] is None
+
+
+# ===========================================================================
+# Current session / template tests
+# ===========================================================================
+
+class TestCurrentSession:
+    async def test_current_session_from_template(
+        self, client: AsyncClient, db_session: AsyncSession, test_user
+    ):
+        inst = await _make_instrument(db_session, test_user, frequency="daily")
+        tmpl, sessions = await _make_template_with_sessions(
+            db_session, test_user, inst,
+            session_names=["Fundamentals", "Repertoire", "Technique"],
+            rotation_index=1,
+        )
+
+        resp = await client.get("/api/today")
+        data = resp.json()
+        due = data["instruments_due"][0]
+        cs = due["current_session"]
+        assert cs is not None
+        assert cs["template_name"] == "Practice Plan"
+        assert cs["session_name"] == "Repertoire"
+        assert cs["rotation_position"] == "session 2 of 3"
+        assert cs["estimated_duration_minutes"] == 10
+        assert cs["section_types"] == ["warmup"]
+
+    async def test_no_template_fallback(
+        self, client: AsyncClient, db_session: AsyncSession, test_user
+    ):
+        await _make_instrument(db_session, test_user, frequency="daily")
+
+        resp = await client.get("/api/today")
+        data = resp.json()
+        due = data["instruments_due"][0]
+        assert due["current_session"] is None
+        assert due["repeat_session"] is None
+        assert due["all_sessions"] == []
+
+
+# ===========================================================================
+# Repeat session tests
+# ===========================================================================
+
+class TestRepeatSession:
+    async def test_repeat_session_populated_when_different(
+        self, client: AsyncClient, db_session: AsyncSession, test_user
+    ):
+        inst = await _make_instrument(db_session, test_user, frequency="daily")
+        tmpl, sessions = await _make_template_with_sessions(
+            db_session, test_user, inst,
+            session_names=["Session A", "Session B"],
+            rotation_index=1,  # current = Session B
+        )
+        # Last completed used Session A
+        await _make_log(
+            db_session, test_user, inst, days_ago=1,
+            template=tmpl, template_session=sessions[0],
+        )
+
+        resp = await client.get("/api/today")
+        data = resp.json()
+        due = data["instruments_due"][0]
+        assert due["repeat_session"] is not None
+        assert due["repeat_session"]["session_name"] == "Session A"
+
+    async def test_repeat_session_null_when_same_as_current(
+        self, client: AsyncClient, db_session: AsyncSession, test_user
+    ):
+        inst = await _make_instrument(db_session, test_user, frequency="daily")
+        tmpl, sessions = await _make_template_with_sessions(
+            db_session, test_user, inst,
+            session_names=["Session A"],
+            rotation_index=0,  # current = Session A
+        )
+        # Last completed also used Session A
+        await _make_log(
+            db_session, test_user, inst, days_ago=1,
+            template=tmpl, template_session=sessions[0],
+        )
+
+        resp = await client.get("/api/today")
+        data = resp.json()
+        due = data["instruments_due"][0]
+        assert due["repeat_session"] is None
+
+    async def test_repeat_session_null_when_no_history(
+        self, client: AsyncClient, db_session: AsyncSession, test_user
+    ):
+        inst = await _make_instrument(db_session, test_user, frequency="daily")
+        await _make_template_with_sessions(
+            db_session, test_user, inst, session_names=["Session A"]
+        )
+
+        resp = await client.get("/api/today")
+        data = resp.json()
+        due = data["instruments_due"][0]
+        assert due["repeat_session"] is None
+
+
+# ===========================================================================
+# All sessions tests
+# ===========================================================================
+
+class TestAllSessions:
+    async def test_all_sessions_populated(
+        self, client: AsyncClient, db_session: AsyncSession, test_user
+    ):
+        inst = await _make_instrument(db_session, test_user, frequency="daily")
+        await _make_template_with_sessions(
+            db_session, test_user, inst,
+            session_names=["Warm-up Day", "Technique Day", "Repertoire Day"],
+        )
+
+        resp = await client.get("/api/today")
+        data = resp.json()
+        due = data["instruments_due"][0]
+        assert len(due["all_sessions"]) == 3
+        names = [s["session_name"] for s in due["all_sessions"]]
+        assert names == ["Warm-up Day", "Technique Day", "Repertoire Day"]
+        assert due["all_sessions"][0]["display_order"] == 0
+        assert due["all_sessions"][2]["display_order"] == 2
+
+
+# ===========================================================================
+# Single instrument endpoint
+# ===========================================================================
+
+class TestSingleInstrument:
+    async def test_returns_scoped_response(
+        self, client: AsyncClient, db_session: AsyncSession, test_user
+    ):
+        inst = await _make_instrument(db_session, test_user, frequency="daily")
+        await _make_instrument(db_session, test_user, name="Piano", frequency="daily")
+
+        resp = await client.get(f"/api/today/{inst.id}")
+        assert resp.status_code == 200
+        data = resp.json()
+        # Only one instrument in results
+        total = len(data["instruments_due"]) + len(data["instruments_not_due"])
+        assert total == 1
+
+    async def test_not_found_returns_404(self, client: AsyncClient):
+        resp = await client.get("/api/today/99999")
+        assert resp.status_code == 404
+
+    async def test_other_user_returns_404(
+        self, client: AsyncClient, db_session: AsyncSession, other_user
+    ):
+        other_inst = Instrument(
+            user_id=other_user.id, name="Guitar", practice_frequency="daily"
+        )
+        db_session.add(other_inst)
+        await db_session.commit()
+        await db_session.refresh(other_inst)
+
+        resp = await client.get(f"/api/today/{other_inst.id}")
+        assert resp.status_code == 404
+
+
+# ===========================================================================
+# Auth
+# ===========================================================================
+
+class TestAuth:
+    async def test_unauthenticated_returns_401(self, unauth_client: AsyncClient):
+        resp = await unauth_client.get("/api/today")
+        assert resp.status_code == 401

--- a/docs/kantelo-frontend-plan.md
+++ b/docs/kantelo-frontend-plan.md
@@ -133,7 +133,8 @@ Build these shared components based on the design tokens doc (section 6). Every 
 - Rotation bar and session label
 - Plan card (focus text, plan source, section type pills)
 - "Start session" button → calls `POST /api/practice/start`, navigates to active session
-- **"Repeat last session" shortcut** — shown when the user's most recent session on this instrument used the same template session that's currently queued. Tapping skips the Today tab and starts a new log immediately. Data for this comes from the `GET /api/today` response (which should include a `repeat_available` flag and the last session's template_session_id).
+- **"Repeat last session" shortcut** — shown when `repeat_session` is non-null in the `GET /api/today` response (i.e., the user's most recent completed session differs from the current rotation pick). Tapping starts a new log with that session's `template_session_id`.
+- **"Choose a different session" picker** — expandable list from `all_sessions` in the Today response, letting users pick any session in the rotation (not just the next one up).
 - "Practice off-plan" link → calls `POST /api/practice/start` with no template, navigates to active session
 - **No-plan state:** if the selected instrument has no active template, show a simplified view with "Practice off-plan" as the primary action and a prompt to create a plan. (Quick-start wizard is Phase 4.)
 - Data source: `GET /api/today`

--- a/docs/kantelo-schema-api.md
+++ b/docs/kantelo-schema-api.md
@@ -568,22 +568,38 @@ The Today tab's data needs — which instruments are due, what's the current ses
 **GET /api/today response:**
 ```json
 {
+  "active_session": {
+    "practice_log_id": 42,
+    "instrument_id": 1,
+    "instrument_name": "Violin",
+    "session_name": "Technique focus",
+    "started_at": "2026-03-23T14:30:00"
+  },
   "instruments_due": [
     {
       "instrument": { "id": 1, "name": "Violin", "practice_frequency": "daily" },
       "last_practiced_at": "2026-03-22",
       "days_since_last": 1,
-      "repeat_available": true,
       "current_session": {
         "template_id": 1,
         "template_name": "Learn the Bruch concerto",
-        "session_id": 3,
-        "session_name": "Technique focus",
-        "focus_description": "Slow practice on mvt. II",
-        "rotation_position": "session 3 of 7",
+        "session_id": 4,
+        "session_name": "Sight reading",
+        "focus_description": null,
+        "rotation_position": "session 4 of 7",
         "estimated_duration_minutes": 25,
         "section_types": ["warmup", "scales", "repertoire", "cooldown"]
-      }
+      },
+      "repeat_session": {
+        "session_id": 3,
+        "session_name": "Technique focus"
+      },
+      "all_sessions": [
+        { "session_id": 1, "session_name": "Fundamentals", "display_order": 0 },
+        { "session_id": 2, "session_name": "Repertoire", "display_order": 1 },
+        { "session_id": 3, "session_name": "Technique focus", "display_order": 2 },
+        { "session_id": 4, "session_name": "Sight reading", "display_order": 3 }
+      ]
     }
   ],
   "instruments_not_due": [
@@ -597,8 +613,7 @@ The Today tab's data needs — which instruments are due, what's the current ses
 }
 ```
 
-`repeat_available` is true when the user's most recent session on this instrument used the same template_session_id that's currently queued. When true, the frontend shows a "Repeat last session" shortcut.
-```
+Session flexibility: instead of a simple `repeat_available` boolean, the response includes `repeat_session` (the user's most recent completed session, shown as a quick shortcut when it differs from `current_session`) and `all_sessions` (every session in the active template, so users can pick any session in the rotation). The `practice/start` endpoint already accepts any `template_session_id`, so users are not locked into the rotation order.
 
 "Due" logic: compare `last_practiced_at` against `practice_frequency`. Daily = due every day. Few times a week = due if ≥ 2 days since last. Weekly = due if ≥ 5 days since last. Occasionally = never auto-surfaced, only shown in pill toggle.
 


### PR DESCRIPTION
## Summary
- Adds `GET /api/today` and `GET /api/today/{instrumentId}` — powers the Today tab with due-instrument logic, active session detection, current template session info, and session selection
- **Design change from spec:** Replaces `repeat_available` boolean with `repeat_session` + `all_sessions`, giving users full flexibility to pick any session in their template rotation (not just the next one up)
- Due logic: daily = always due, few_times_a_week = due if ≥2 days, weekly = due if ≥5 days, occasionally = never auto-surfaced
- 23 integration tests covering all frequencies, edge cases (rotation wrap-around, deleted instruments, mixed due/not-due), active session with templates, repeat session logic, and auth

## Test plan
- [x] All 23 new tests pass (`pytest tests/test_today_api.py -v`)
- [x] Full suite passes (221 → 225 tests, 0 failures)
- [ ] Manual smoke test: `GET /api/today` returns correct due/not-due split for instruments with varying practice histories

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)