### PR TITLE
Make the app deploy-ready for Railway (#142)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -14,10 +14,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy application code
 COPY . .
 
-# Expose port
-EXPOSE 8000
+# Expose port (Railway sets PORT env var; default to 8000)
+EXPOSE ${PORT:-8000}
 
-# Command will be overridden by docker-compose
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
-
-
+# Start script: run migrations then start the server.
+# Railway sets PORT automatically; fall back to 8000 for local Docker.
+CMD ["sh", "-c", "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -7,6 +7,7 @@ class Settings(BaseSettings):
     database_url: str = "postgresql+asyncpg://practice_user:practice_pass@localhost:5432/practice_journal"
     environment: str = "development"
     api_prefix: str = "/api"
+    cors_origins: str = "http://localhost:3000"
 
     # Clerk authentication settings
     clerk_secret_key: str = ""

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,3 +1,4 @@
+from pydantic import field_validator
 from pydantic_settings import BaseSettings
 from functools import lru_cache
 
@@ -6,11 +7,25 @@ class Settings(BaseSettings):
     database_url: str = "postgresql+asyncpg://practice_user:practice_pass@localhost:5432/practice_journal"
     environment: str = "development"
     api_prefix: str = "/api"
-    
+
     # Clerk authentication settings
     clerk_secret_key: str = ""
     clerk_publishable_key: str = ""
-    
+
+    @field_validator("database_url")
+    @classmethod
+    def ensure_asyncpg_driver(cls, v: str) -> str:
+        """Normalize DATABASE_URL to use the asyncpg driver.
+
+        Cloud platforms (Railway, Render) provide postgresql:// URLs.
+        SQLAlchemy needs postgresql+asyncpg:// for the async engine.
+        """
+        if v.startswith("postgresql://"):
+            return v.replace("postgresql://", "postgresql+asyncpg://", 1)
+        if v.startswith("postgres://"):
+            return v.replace("postgres://", "postgresql+asyncpg://", 1)
+        return v
+
     class Config:
         env_file = ".env"
         case_sensitive = False

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -38,13 +38,11 @@ app = FastAPI(
 )
 
 # CORS middleware for frontend.
-# CORS_ORIGINS env var is a comma-separated list of allowed origins.
-# Falls back to localhost for local development.
-import os
-_cors_origins = os.getenv("CORS_ORIGINS", "http://localhost:3000").split(",")
+# CORS_ORIGINS setting is a comma-separated list of allowed origins.
+_cors_origins = [o.strip() for o in settings.cors_origins.split(",") if o.strip()]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[o.strip() for o in _cors_origins],
+    allow_origins=_cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -37,10 +37,14 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-# CORS middleware for frontend
+# CORS middleware for frontend.
+# CORS_ORIGINS env var is a comma-separated list of allowed origins.
+# Falls back to localhost for local development.
+import os
+_cors_origins = os.getenv("CORS_ORIGINS", "http://localhost:3000").split(",")
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000"],
+    allow_origins=[o.strip() for o in _cors_origins],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/docs/railway-deployment.md
+++ b/docs/railway-deployment.md
@@ -1,0 +1,144 @@
+# Deploying Kantelo to Railway
+
+This guide walks through deploying the Kantelo backend (FastAPI) and frontend (Next.js) to [Railway](https://railway.com) with a managed PostgreSQL database.
+
+**Cost:** ~$5/month on the Hobby plan (includes $5 usage credit).
+
+---
+
+## Prerequisites
+
+- A Railway account (sign up at [railway.com](https://railway.com))
+- A Clerk account with API keys (sign up at [clerk.com](https://clerk.com))
+- This repository pushed to GitHub
+
+---
+
+## 1. Create a Railway project
+
+1. Go to [railway.com/new](https://railway.com/new)
+2. Select **"Deploy from GitHub Repo"**
+3. Connect your GitHub account and select the `practice-journal` repository
+4. Railway will create a project — don't deploy yet, we need to configure services first
+
+---
+
+## 2. Add PostgreSQL
+
+1. In your Railway project, click **"+ New"** → **"Database"** → **"PostgreSQL"**
+2. Railway provisions a managed Postgres instance and exposes a `DATABASE_URL` variable
+3. Note: Railway's `DATABASE_URL` uses `postgresql://` — the backend automatically converts this to `postgresql+asyncpg://` for the async driver
+
+---
+
+## 3. Deploy the backend
+
+1. In your Railway project, click **"+ New"** → **"GitHub Repo"** → select `practice-journal`
+2. In the service settings:
+   - **Root Directory:** `backend`
+   - **Build Command:** (leave default — Railway will auto-detect the Dockerfile)
+3. Add these **environment variables** (Settings → Variables):
+
+   | Variable | Value |
+   |----------|-------|
+   | `DATABASE_URL` | Click **"Add Reference"** → select the Postgres service's `DATABASE_URL` |
+   | `CLERK_SECRET_KEY` | Your Clerk secret key (from [dashboard.clerk.com](https://dashboard.clerk.com)) |
+   | `CLERK_PUBLISHABLE_KEY` | Your Clerk publishable key |
+   | `CORS_ORIGINS` | The frontend's Railway URL (you'll get this in step 4 — come back and set it) |
+   | `ENVIRONMENT` | `production` |
+
+4. Deploy. The Dockerfile runs `alembic upgrade head` before starting uvicorn, so migrations run automatically on every deploy.
+
+5. Once deployed, note the backend's public URL (e.g., `https://kantelo-backend-production.up.railway.app`). You'll need this for the frontend.
+
+---
+
+## 4. Deploy the frontend
+
+1. In your Railway project, click **"+ New"** → **"GitHub Repo"** → select `practice-journal` again
+2. In the service settings:
+   - **Root Directory:** `frontend`
+   - **Build Command:** (leave default — Railway will auto-detect the Dockerfile)
+3. Add these **environment variables**:
+
+   | Variable | Value |
+   |----------|-------|
+   | `NEXT_PUBLIC_API_URL` | The backend's Railway URL from step 3 (e.g., `https://kantelo-backend-production.up.railway.app`) |
+   | `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | Your Clerk publishable key |
+   | `CLERK_SECRET_KEY` | Your Clerk secret key |
+   | `NEXT_PUBLIC_CLERK_SIGN_IN_URL` | `/sign-in` |
+   | `NEXT_PUBLIC_CLERK_SIGN_UP_URL` | `/sign-up` |
+   | `NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL` | `/` |
+   | `NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL` | `/` |
+
+4. Deploy. Note the frontend's public URL.
+
+5. **Go back to step 3** and set the backend's `CORS_ORIGINS` variable to the frontend URL (e.g., `https://kantelo-frontend-production.up.railway.app`).
+
+---
+
+## 5. Configure Clerk
+
+1. In your [Clerk dashboard](https://dashboard.clerk.com), go to your application settings
+2. Under **"Domains"**, add both the frontend Railway URL and the backend Railway URL as allowed origins
+3. If you later add a custom domain (e.g., `kantelo.app`), add that too
+
+---
+
+## 6. Seed the curated block library (optional)
+
+Railway provides a shell for each service. To seed the global block library:
+
+1. Go to the backend service in Railway
+2. Open the **"Shell"** tab (or use `railway run` via the CLI)
+3. Run: `python scripts/seed_curated_blocks.py`
+
+---
+
+## 7. Verify
+
+1. Visit the backend URL + `/health` — should return `{"status": "healthy"}`
+2. Visit the backend URL + `/docs` — should show the Swagger UI
+3. Visit the frontend URL — should show the Clerk sign-in page
+4. Sign in and verify the API works (instrument list, etc.)
+
+---
+
+## Custom domain (optional)
+
+Railway supports custom domains on all paid plans:
+
+1. In Railway, go to your frontend service → **Settings** → **Domains**
+2. Click **"+ Custom Domain"** and enter your domain (e.g., `kantelo.app`)
+3. Railway will provide DNS records (CNAME) to add at your domain registrar
+4. Do the same for the backend if you want `api.kantelo.app`
+5. Update `CORS_ORIGINS` and Clerk allowed origins to include the custom domain
+
+---
+
+## Automatic deploys
+
+Railway auto-deploys on every push to your default branch. To change this:
+
+- Go to service **Settings** → **Deploy** → configure the branch trigger
+- You can also enable PR preview environments (creates a temporary deploy per PR)
+
+---
+
+## Troubleshooting
+
+**Backend won't start:**
+- Check the deploy logs in Railway for the service
+- Verify `DATABASE_URL` is set (click the variable and confirm it resolves)
+- Check that Alembic migrations succeeded in the deploy log
+
+**Auth not working:**
+- Verify `CLERK_SECRET_KEY` is set on both backend and frontend
+- Verify `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` is set on the frontend
+- Check that the Railway URLs are added to Clerk's allowed origins
+
+**CORS errors:**
+- Verify `CORS_ORIGINS` on the backend includes the exact frontend URL (with `https://`, no trailing slash)
+
+**Database connection errors:**
+- The `DATABASE_URL` reference from the Postgres service should auto-update. If you see connection errors, check that the Postgres service is running.

--- a/docs/railway-deployment.md
+++ b/docs/railway-deployment.md
@@ -59,7 +59,8 @@ This guide walks through deploying the Kantelo backend (FastAPI) and frontend (N
 2. In the service settings:
    - **Root Directory:** `frontend`
    - **Build Command:** (leave default — Railway will auto-detect the Dockerfile)
-3. Add these **environment variables**:
+3. The `frontend/railway.toml` file automatically passes `NEXT_PUBLIC_*` env vars as Docker build args so they're available at Next.js build time. You just need to set them as regular environment variables.
+4. Add these **environment variables**:
 
    | Variable | Value |
    |----------|-------|

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,20 +1,43 @@
-FROM node:20-alpine
+FROM node:20-alpine AS base
 
 WORKDIR /app
 
-# Copy package files
+# --- Dependencies ---
+FROM base AS deps
 COPY package*.json ./
+RUN npm ci
 
-# Install dependencies
-RUN npm install
-
-# Copy application code
+# --- Build ---
+FROM base AS builder
+COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
-# Expose port
-EXPOSE 3000
+# Build args for Next.js (needed at build time for static optimization)
+ARG NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+ARG NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in
+ARG NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up
+ARG NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL=/
+ARG NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL=/
+ARG NEXT_PUBLIC_API_URL
 
-# Command will be overridden by docker-compose
-CMD ["npm", "run", "dev"]
+ENV NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=$NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+ENV NEXT_PUBLIC_CLERK_SIGN_IN_URL=$NEXT_PUBLIC_CLERK_SIGN_IN_URL
+ENV NEXT_PUBLIC_CLERK_SIGN_UP_URL=$NEXT_PUBLIC_CLERK_SIGN_UP_URL
+ENV NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL=$NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL
+ENV NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL=$NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
 
+RUN npm run build
 
+# --- Production ---
+FROM base AS runner
+ENV NODE_ENV=production
+
+# Copy built assets
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+COPY --from=builder /app/public ./public
+
+# Railway sets PORT automatically; default to 3000
+EXPOSE ${PORT:-3000}
+CMD ["sh", "-c", "PORT=${PORT:-3000} node server.js"]

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  // Standalone output for production Docker builds (smaller image,
+  // includes only the files needed to run the server).
+  output: 'standalone',
   async rewrites() {
     return [
       {

--- a/frontend/railway.toml
+++ b/frontend/railway.toml
@@ -1,0 +1,18 @@
+[build]
+# Pass NEXT_PUBLIC_* env vars as Docker build args so they're available
+# at Next.js build time for static optimization. Railway injects these
+# from the service's environment variables automatically when listed here.
+dockerfilePath = "Dockerfile"
+
+[build.args]
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "${{NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}}"
+NEXT_PUBLIC_CLERK_SIGN_IN_URL = "${{NEXT_PUBLIC_CLERK_SIGN_IN_URL}}"
+NEXT_PUBLIC_CLERK_SIGN_UP_URL = "${{NEXT_PUBLIC_CLERK_SIGN_UP_URL}}"
+NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL = "${{NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL}}"
+NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL = "${{NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL}}"
+NEXT_PUBLIC_API_URL = "${{NEXT_PUBLIC_API_URL}}"
+
+[deploy]
+healthcheckPath = "/"
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 3


### PR DESCRIPTION
## Summary
Make both services deploy-ready for Railway cloud hosting.

- **Backend Dockerfile**: runs `alembic upgrade head` before starting uvicorn so migrations are automatic
- **Backend config**: `DATABASE_URL` auto-normalized from `postgresql://` to `postgresql+asyncpg://` (Railway provides the former, SQLAlchemy needs the latter)
- **Backend CORS**: configurable via `CORS_ORIGINS` env var instead of hardcoded `localhost:3000`
- **Frontend Dockerfile**: multi-stage production build (deps → build → slim runner) with build-time env vars for Next.js static optimization
- **Frontend next.config.js**: standalone output mode enabled
- **Deployment guide**: `docs/railway-deployment.md` with step-by-step setup

## What's needed after merge
This PR makes the code deploy-ready. The actual deployment is a manual step:
1. Create a Railway project
2. Add Postgres
3. Add backend + frontend services pointing to subdirectories
4. Set env vars per the guide
5. Configure Clerk allowed origins

## Test plan
- [x] 442 backend tests pass (no regressions)
- [x] Local Docker Compose still works (CMD is overridden by docker-compose.yml)
- [ ] Review the DATABASE_URL normalization for edge cases
- [ ] Review the CORS_ORIGINS parsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
