### PR TITLE
Add active session screen — standard flow (#145, part 1 of 2)

### DIFF
--- a/frontend/src/app/session/[id]/page.tsx
+++ b/frontend/src/app/session/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback, useRef } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { useApi } from '@/lib/useApi'
@@ -17,6 +17,9 @@ import type {
 
 export default function ActiveSessionPage() {
   const api = useApi()
+  const apiRef = useRef(api)
+  apiRef.current = api
+
   const router = useRouter()
   const params = useParams()
   const logId = Number(params.id)
@@ -29,24 +32,32 @@ export default function ActiveSessionPage() {
   const fetchLog = useCallback(async () => {
     try {
       setLoading(true)
-      const data = await api.getPractice(logId)
+      const data = await apiRef.current.getPractice(logId)
       setLog(data)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load session')
     } finally {
       setLoading(false)
     }
-  }, [api, logId])
+  }, [logId])
 
   useEffect(() => {
     if (logId) fetchLog()
   }, [logId, fetchLog])
 
+  // Collect pending note-save callbacks so we can flush before finish
+  const pendingFlushes = useRef<Set<() => Promise<void>>>(new Set())
+
   const handleFinish = async () => {
     if (!log) return
     setFinishing(true)
     try {
-      const result: FinishResponse = await api.finishPractice(log.id)
+      // Flush any unsaved notes (covers the case where the user taps
+      // Finish without blurring a note field first)
+      const flushes = Array.from(pendingFlushes.current)
+      await Promise.all(flushes.map((fn) => fn()))
+
+      const result: FinishResponse = await apiRef.current.finishPractice(log.id)
       // Navigate to summary with the finish data
       // For now, store in sessionStorage since we don't have a summary page yet
       sessionStorage.setItem(
@@ -101,9 +112,13 @@ export default function ActiveSessionPage() {
             </h1>
           </div>
           <button
-            onClick={() => {
+            onClick={async () => {
               if (confirm('Abandon this session?')) {
-                api.updatePractice(log.id, { status: 'abandoned' })
+                try {
+                  await apiRef.current.updatePractice(log.id, { status: 'abandoned' })
+                } catch {
+                  // Navigate anyway — the session can be cleaned up later
+                }
                 router.push('/today')
               }
             }}
@@ -144,6 +159,7 @@ export default function ActiveSessionPage() {
             logId={log.id}
             sectionLog={sl}
             onUpdate={fetchLog}
+            pendingFlushes={pendingFlushes}
           />
         ))}
 
@@ -151,7 +167,11 @@ export default function ActiveSessionPage() {
         <AddSectionButton logId={log.id} onAdd={fetchLog} />
 
         {/* Session notes */}
-        <SessionNotes logId={log.id} initialNotes={log.notes ?? ''} />
+        <SessionNotes
+          logId={log.id}
+          initialNotes={log.notes ?? ''}
+          pendingFlushes={pendingFlushes}
+        />
 
         {/* Finish button */}
         <button
@@ -174,10 +194,12 @@ function SectionCard({
   logId,
   sectionLog,
   onUpdate,
+  pendingFlushes,
 }: {
   logId: number
   sectionLog: SectionLog
   onUpdate: () => void
+  pendingFlushes: React.RefObject<Set<() => Promise<void>>>
 }) {
   const api = useApi()
   const isCompleted = sectionLog.completed
@@ -196,6 +218,10 @@ function SectionCard({
   }
 
   const handleSkipSection = async () => {
+    const hasRatings = sectionLog.block_logs.some((bl) => bl.rating !== null)
+    if (hasRatings && !confirm('Skipping will clear ratings in this section. Continue?')) {
+      return
+    }
     await api.updateSectionLog(logId, sectionLog.id, { completed: false })
     onUpdate()
   }
@@ -244,6 +270,7 @@ function SectionCard({
             logId={logId}
             blockLog={bl}
             onUpdate={onUpdate}
+            pendingFlushes={pendingFlushes}
           />
         ))}
       </div>
@@ -266,10 +293,12 @@ function BlockRow({
   logId,
   blockLog,
   onUpdate,
+  pendingFlushes,
 }: {
   logId: number
   blockLog: BlockLog
   onUpdate: () => void
+  pendingFlushes: React.RefObject<Set<() => Promise<void>>>
 }) {
   const api = useApi()
   const [showNotes, setShowNotes] = useState(!!blockLog.notes)
@@ -291,14 +320,23 @@ function BlockRow({
     onUpdate()
   }
 
-  const handleSaveNotes = async () => {
+  const handleSaveNotes = useCallback(async () => {
     setSavingNotes(true)
     try {
       await api.updateBlockLog(logId, blockLog.id, { notes })
     } finally {
       setSavingNotes(false)
     }
-  }
+  }, [api, logId, blockLog.id, notes])
+
+  // Register/unregister the flush callback so Finish can save pending notes
+  useEffect(() => {
+    const flushes = pendingFlushes.current
+    if (showNotes && notes !== (blockLog.notes ?? '')) {
+      flushes?.add(handleSaveNotes)
+      return () => { flushes?.delete(handleSaveNotes) }
+    }
+  }, [showNotes, notes, blockLog.notes, handleSaveNotes, pendingFlushes])
 
   return (
     <div className={`px-4 py-3 ${!blockLog.completed ? '' : 'bg-gray-50/50'}`}>
@@ -512,16 +550,27 @@ function AddSectionButton({
 function SessionNotes({
   logId,
   initialNotes,
+  pendingFlushes,
 }: {
   logId: number
   initialNotes: string
+  pendingFlushes: React.RefObject<Set<() => Promise<void>>>
 }) {
   const api = useApi()
   const [notes, setNotes] = useState(initialNotes)
 
-  const handleSave = async () => {
+  const handleSave = useCallback(async () => {
     await api.updatePractice(logId, { notes: notes || undefined })
-  }
+  }, [api, logId, notes])
+
+  // Register flush so Finish saves pending session notes
+  useEffect(() => {
+    const flushes = pendingFlushes.current
+    if (notes !== initialNotes) {
+      flushes?.add(handleSave)
+      return () => { flushes?.delete(handleSave) }
+    }
+  }, [notes, initialNotes, handleSave, pendingFlushes])
 
   return (
     <div>

--- a/frontend/src/app/session/[id]/page.tsx
+++ b/frontend/src/app/session/[id]/page.tsx
@@ -1,0 +1,559 @@
+'use client'
+
+import { useEffect, useState, useCallback } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { useApi } from '@/lib/useApi'
+import RatingChevrons from '@/components/RatingChevrons'
+import TimeStepper from '@/components/TimeStepper'
+import type {
+  PracticeLog,
+  SectionLog,
+  BlockLog,
+  Rating,
+  FinishResponse,
+  SectionType,
+} from '@/lib/types'
+
+export default function ActiveSessionPage() {
+  const api = useApi()
+  const router = useRouter()
+  const params = useParams()
+  const logId = Number(params.id)
+
+  const [log, setLog] = useState<PracticeLog | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [finishing, setFinishing] = useState(false)
+
+  const fetchLog = useCallback(async () => {
+    try {
+      setLoading(true)
+      const data = await api.getPractice(logId)
+      setLog(data)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load session')
+    } finally {
+      setLoading(false)
+    }
+  }, [api, logId])
+
+  useEffect(() => {
+    if (logId) fetchLog()
+  }, [logId, fetchLog])
+
+  const handleFinish = async () => {
+    if (!log) return
+    setFinishing(true)
+    try {
+      const result: FinishResponse = await api.finishPractice(log.id)
+      // Navigate to summary with the finish data
+      // For now, store in sessionStorage since we don't have a summary page yet
+      sessionStorage.setItem(
+        `session-summary-${log.id}`,
+        JSON.stringify(result)
+      )
+      router.push(`/session/${log.id}/summary`)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to finish session')
+      setFinishing(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[calc(100vh-4rem)]">
+        <div className="text-gray-500">Loading session...</div>
+      </div>
+    )
+  }
+
+  if (error || !log) {
+    return (
+      <div className="flex items-center justify-center min-h-[calc(100vh-4rem)] px-6">
+        <div className="text-center">
+          <p className="text-red-600 mb-3">{error || 'Session not found'}</p>
+          <Link href="/today" className="text-primary-600 underline text-sm">
+            Back to Today
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  // Compute progress
+  const allBlocks = log.section_logs.flatMap((sl) => sl.block_logs)
+  const completedCount = allBlocks.filter((bl) => bl.completed).length
+  const totalCount = allBlocks.length
+  const totalMinutes = log.section_logs.reduce(
+    (sum, sl) => sum + sl.actual_duration_minutes,
+    0
+  )
+
+  return (
+    <main className="min-h-screen bg-gray-50">
+      {/* Top bar */}
+      <div className="sticky top-0 bg-white border-b border-gray-200 z-40 px-4 py-3">
+        <div className="max-w-lg mx-auto flex items-center justify-between">
+          <div className="flex-1 min-w-0">
+            <h1 className="text-base font-semibold text-gray-900 truncate">
+              {log.session_name ?? log.template_name ?? 'Practice session'}
+            </h1>
+          </div>
+          <button
+            onClick={() => {
+              if (confirm('Abandon this session?')) {
+                api.updatePractice(log.id, { status: 'abandoned' })
+                router.push('/today')
+              }
+            }}
+            className="text-sm text-gray-500 hover:text-gray-700 ml-3"
+          >
+            End session
+          </button>
+        </div>
+      </div>
+
+      {/* Progress bar */}
+      <div className="bg-white border-b border-gray-100 px-4 py-2">
+        <div className="max-w-lg mx-auto">
+          <div className="flex justify-between text-xs text-gray-500 mb-1">
+            <span>
+              {completedCount} of {totalCount} done
+            </span>
+            <span>Total: {totalMinutes} min</span>
+          </div>
+          <div className="h-1.5 bg-gray-100 rounded-full overflow-hidden">
+            <div
+              className="h-full bg-primary-500 rounded-full transition-all duration-300"
+              style={{
+                width: totalCount > 0
+                  ? `${(completedCount / totalCount) * 100}%`
+                  : '0%',
+              }}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Sections */}
+      <div className="max-w-lg mx-auto px-4 py-4 space-y-4">
+        {log.section_logs.map((sl) => (
+          <SectionCard
+            key={sl.id}
+            logId={log.id}
+            sectionLog={sl}
+            onUpdate={fetchLog}
+          />
+        ))}
+
+        {/* Add freeform section */}
+        <AddSectionButton logId={log.id} onAdd={fetchLog} />
+
+        {/* Session notes */}
+        <SessionNotes logId={log.id} initialNotes={log.notes ?? ''} />
+
+        {/* Finish button */}
+        <button
+          onClick={handleFinish}
+          disabled={finishing}
+          className="w-full py-3 bg-primary-600 text-white rounded-xl font-medium text-base hover:bg-primary-700 transition-colors shadow-sm disabled:opacity-60"
+        >
+          {finishing ? 'Finishing...' : 'Finish session'}
+        </button>
+      </div>
+    </main>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Section card
+// ---------------------------------------------------------------------------
+
+function SectionCard({
+  logId,
+  sectionLog,
+  onUpdate,
+}: {
+  logId: number
+  sectionLog: SectionLog
+  onUpdate: () => void
+}) {
+  const api = useApi()
+  const isCompleted = sectionLog.completed
+  const isSkipped = !sectionLog.completed && sectionLog.block_logs.every((bl) => !bl.completed)
+
+  const handleTimeChange = async (minutes: number) => {
+    await api.updateSectionLog(logId, sectionLog.id, {
+      actual_duration_minutes: minutes,
+    })
+    onUpdate()
+  }
+
+  const handleMarkAllDone = async () => {
+    await api.updateSectionLog(logId, sectionLog.id, { mark_all_done: true })
+    onUpdate()
+  }
+
+  const handleSkipSection = async () => {
+    await api.updateSectionLog(logId, sectionLog.id, { completed: false })
+    onUpdate()
+  }
+
+  return (
+    <div
+      className={`bg-white rounded-xl border border-gray-200 shadow-sm transition-opacity ${
+        isSkipped ? 'opacity-50' : isCompleted ? 'opacity-75' : ''
+      }`}
+    >
+      {/* Section header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100">
+        <div className="flex items-center gap-2 min-w-0">
+          <SectionTypeIcon type={sectionLog.section_type} />
+          <h3 className="font-medium text-gray-900 text-sm truncate">
+            {sectionLog.section_name}
+          </h3>
+        </div>
+        <TimeStepper
+          value={sectionLog.actual_duration_minutes}
+          onChange={handleTimeChange}
+        />
+      </div>
+
+      {/* Section actions */}
+      <div className="flex gap-4 px-4 py-1.5 border-b border-gray-50">
+        <button
+          onClick={handleMarkAllDone}
+          className="text-xs text-gray-500 hover:text-gray-700"
+        >
+          Mark all done
+        </button>
+        <button
+          onClick={handleSkipSection}
+          className="text-xs text-gray-500 hover:text-gray-700"
+        >
+          Skip section
+        </button>
+      </div>
+
+      {/* Block rows */}
+      <div className="divide-y divide-gray-50">
+        {sectionLog.block_logs.map((bl) => (
+          <BlockRow
+            key={bl.id}
+            logId={logId}
+            blockLog={bl}
+            onUpdate={onUpdate}
+          />
+        ))}
+      </div>
+
+      {/* Quick-add block */}
+      <QuickAddBlock
+        logId={logId}
+        sectionLogId={sectionLog.id}
+        onAdd={onUpdate}
+      />
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Block row (exercise)
+// ---------------------------------------------------------------------------
+
+function BlockRow({
+  logId,
+  blockLog,
+  onUpdate,
+}: {
+  logId: number
+  blockLog: BlockLog
+  onUpdate: () => void
+}) {
+  const api = useApi()
+  const [showNotes, setShowNotes] = useState(!!blockLog.notes)
+  const [notes, setNotes] = useState(blockLog.notes ?? '')
+  const [savingNotes, setSavingNotes] = useState(false)
+
+  const handleToggleCompleted = async () => {
+    await api.updateBlockLog(logId, blockLog.id, {
+      completed: !blockLog.completed,
+    })
+    onUpdate()
+  }
+
+  const handleRating = async (rating: Rating) => {
+    await api.updateBlockLog(logId, blockLog.id, {
+      rating,
+      completed: true,
+    })
+    onUpdate()
+  }
+
+  const handleSaveNotes = async () => {
+    setSavingNotes(true)
+    try {
+      await api.updateBlockLog(logId, blockLog.id, { notes })
+    } finally {
+      setSavingNotes(false)
+    }
+  }
+
+  return (
+    <div className={`px-4 py-3 ${!blockLog.completed ? '' : 'bg-gray-50/50'}`}>
+      <div className="flex items-center gap-3">
+        {/* Checkbox */}
+        <button
+          onClick={handleToggleCompleted}
+          className={`w-5 h-5 rounded border flex items-center justify-center flex-shrink-0 ${
+            blockLog.completed
+              ? 'bg-primary-600 border-primary-600 text-white'
+              : 'border-gray-300 hover:border-primary-400'
+          }`}
+          aria-label={blockLog.completed ? 'Mark incomplete' : 'Mark complete'}
+        >
+          {blockLog.completed && (
+            <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" strokeWidth={3} stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+            </svg>
+          )}
+        </button>
+
+        {/* Name + metadata */}
+        <div className="flex-1 min-w-0">
+          <p className={`text-sm ${blockLog.completed ? 'text-gray-500' : 'text-gray-900'}`}>
+            {blockLog.block_name}
+          </p>
+          {blockLog.last_tempo_bpm && (
+            <p className="text-xs text-gray-400">
+              Last tempo: {blockLog.last_tempo_bpm} bpm
+            </p>
+          )}
+        </div>
+
+        {/* Rating */}
+        <RatingChevrons
+          value={blockLog.rating}
+          onChange={handleRating}
+        />
+      </div>
+
+      {/* Notes toggle + field */}
+      <div className="mt-1 ml-8">
+        {!showNotes ? (
+          <button
+            onClick={() => setShowNotes(true)}
+            className="text-xs text-gray-400 hover:text-gray-600"
+          >
+            + add note
+          </button>
+        ) : (
+          <div className="mt-1">
+            <textarea
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              onBlur={handleSaveNotes}
+              placeholder="Notes..."
+              rows={2}
+              className="w-full text-xs text-gray-700 border border-gray-200 rounded-lg px-2.5 py-1.5 resize-none focus:outline-none focus:border-primary-400"
+            />
+            {savingNotes && (
+              <span className="text-xs text-gray-400">Saving...</span>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Quick-add block
+// ---------------------------------------------------------------------------
+
+function QuickAddBlock({
+  logId,
+  sectionLogId,
+  onAdd,
+}: {
+  logId: number
+  sectionLogId: number
+  onAdd: () => void
+}) {
+  const api = useApi()
+  const [name, setName] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const trimmed = name.trim()
+    if (!trimmed) return
+    await api.addFreeformBlock(logId, sectionLogId, { block_name: trimmed })
+    setName('')
+    onAdd()
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="px-4 py-2 border-t border-gray-100">
+      <input
+        type="text"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="Add something else..."
+        className="w-full text-xs text-gray-600 bg-transparent py-1 focus:outline-none placeholder-gray-400"
+      />
+    </form>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Add freeform section
+// ---------------------------------------------------------------------------
+
+function AddSectionButton({
+  logId,
+  onAdd,
+}: {
+  logId: number
+  onAdd: () => void
+}) {
+  const api = useApi()
+  const [open, setOpen] = useState(false)
+  const [name, setName] = useState('')
+  const [type, setType] = useState<SectionType>('other')
+
+  const sectionTypes: { value: SectionType; label: string }[] = [
+    { value: 'warmup', label: 'Warm-up' },
+    { value: 'scales', label: 'Scales' },
+    { value: 'repertoire', label: 'Repertoire' },
+    { value: 'sight_reading', label: 'Sight-reading' },
+    { value: 'ear_training', label: 'Ear training' },
+    { value: 'cooldown', label: 'Cool-down' },
+    { value: 'other', label: 'Other' },
+  ]
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const trimmed = name.trim()
+    if (!trimmed) return
+    await api.addFreeformSection(logId, {
+      section_name: trimmed,
+      section_type: type,
+    })
+    setName('')
+    setType('other')
+    setOpen(false)
+    onAdd()
+  }
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="w-full py-2.5 border-2 border-dashed border-gray-300 rounded-xl text-sm text-gray-500 hover:border-gray-400 hover:text-gray-600 transition-colors"
+      >
+        + Add a section
+      </button>
+    )
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="bg-white rounded-xl border border-gray-200 shadow-sm p-4 space-y-3"
+    >
+      <input
+        type="text"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="Section name..."
+        autoFocus
+        className="w-full text-sm border border-gray-200 rounded-lg px-3 py-2 focus:outline-none focus:border-primary-400"
+      />
+      <div className="flex flex-wrap gap-2">
+        {sectionTypes.map((st) => (
+          <button
+            key={st.value}
+            type="button"
+            onClick={() => setType(st.value)}
+            className={`px-3 py-1 rounded-full text-xs transition-colors ${
+              type === st.value
+                ? 'bg-primary-100 text-primary-700 font-medium'
+                : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+            }`}
+          >
+            {st.label}
+          </button>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        <button
+          type="submit"
+          className="px-4 py-1.5 bg-primary-600 text-white rounded-lg text-sm font-medium hover:bg-primary-700"
+        >
+          Add
+        </button>
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          className="px-4 py-1.5 text-gray-500 text-sm hover:text-gray-700"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Session notes
+// ---------------------------------------------------------------------------
+
+function SessionNotes({
+  logId,
+  initialNotes,
+}: {
+  logId: number
+  initialNotes: string
+}) {
+  const api = useApi()
+  const [notes, setNotes] = useState(initialNotes)
+
+  const handleSave = async () => {
+    await api.updatePractice(logId, { notes: notes || undefined })
+  }
+
+  return (
+    <div>
+      <textarea
+        value={notes}
+        onChange={(e) => setNotes(e.target.value)}
+        onBlur={handleSave}
+        placeholder="Notes — breakthroughs, challenges, ideas..."
+        rows={3}
+        className="w-full text-sm text-gray-700 border border-gray-200 rounded-xl px-4 py-3 resize-none focus:outline-none focus:border-primary-400"
+      />
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Section type icon (colored dot)
+// ---------------------------------------------------------------------------
+
+function SectionTypeIcon({ type }: { type: string }) {
+  const colors: Record<string, string> = {
+    warmup: 'bg-orange-400',
+    scales: 'bg-blue-400',
+    repertoire: 'bg-purple-400',
+    sight_reading: 'bg-green-400',
+    ear_training: 'bg-cyan-400',
+    cooldown: 'bg-indigo-400',
+    other: 'bg-gray-400',
+  }
+  return (
+    <span
+      className={`w-2.5 h-2.5 rounded-full flex-shrink-0 ${colors[type] ?? 'bg-gray-400'}`}
+    />
+  )
+}

--- a/frontend/src/app/session/[id]/summary/page.tsx
+++ b/frontend/src/app/session/[id]/summary/page.tsx
@@ -25,12 +25,45 @@ export default function SessionSummaryPage() {
         sessionStorage.removeItem(`session-summary-${logId}`)
         return
       } catch {
-        // fall through to redirect
+        // fall through to API fallback
       }
     }
-    // If no cached data, we can't show the summary — redirect to today
-    router.replace('/today')
-  }, [logId, router])
+
+    // Fallback: reconstruct from the API (handles page refresh).
+    // We can't get the full FinishResponse, but we can show the practice log.
+    const loadFromApi = async () => {
+      try {
+        const log = await api.getPractice(logId)
+        if (log.status !== 'completed') {
+          router.replace(`/session/${logId}`)
+          return
+        }
+        // Build a partial summary from the log data
+        const allBlocks = log.section_logs.flatMap((sl) => sl.block_logs)
+        const completed = allBlocks.filter((bl) => bl.completed)
+        const sf = completed.filter((bl) => bl.rating === 1).length
+        const st = completed.filter((bl) => bl.rating === 0).length
+        const sb = completed.filter((bl) => bl.rating === -1).length
+        const sk = allBlocks.length - completed.length
+
+        setData({
+          practice_log: log,
+          summary: {
+            total_duration_minutes: log.total_duration_minutes,
+            exercises_completed: completed.length,
+            exercises_total: allBlocks.length,
+            day_streak: 0, // can't reconstruct from log alone
+            ratings: { step_forward: sf, steady: st, step_back: sb, skipped: sk },
+          },
+          coaching_suggestion: null,
+          reflection_prompt: log.reflection_prompt,
+        })
+      } catch {
+        router.replace('/today')
+      }
+    }
+    loadFromApi()
+  }, [logId, router, api])
 
   const handleSaveReflection = async () => {
     if (!reflection.trim()) return

--- a/frontend/src/app/session/[id]/summary/page.tsx
+++ b/frontend/src/app/session/[id]/summary/page.tsx
@@ -1,0 +1,165 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { useApi } from '@/lib/useApi'
+import type { FinishResponse } from '@/lib/types'
+
+export default function SessionSummaryPage() {
+  const router = useRouter()
+  const params = useParams()
+  const api = useApi()
+  const logId = Number(params.id)
+
+  const [data, setData] = useState<FinishResponse | null>(null)
+  const [reflection, setReflection] = useState('')
+  const [reflectionSaved, setReflectionSaved] = useState(false)
+
+  useEffect(() => {
+    // Try to load from sessionStorage (set by the finish flow)
+    const cached = sessionStorage.getItem(`session-summary-${logId}`)
+    if (cached) {
+      try {
+        setData(JSON.parse(cached))
+        sessionStorage.removeItem(`session-summary-${logId}`)
+        return
+      } catch {
+        // fall through to redirect
+      }
+    }
+    // If no cached data, we can't show the summary — redirect to today
+    router.replace('/today')
+  }, [logId, router])
+
+  const handleSaveReflection = async () => {
+    if (!reflection.trim()) return
+    try {
+      await api.saveReflection(logId, { reflection_response: reflection })
+      setReflectionSaved(true)
+    } catch {
+      // silently fail — not critical
+    }
+  }
+
+  if (!data) return null
+
+  const { summary, coaching_suggestion, reflection_prompt } = data
+  const { ratings } = summary
+
+  return (
+    <main className="min-h-screen bg-gray-50 px-4 py-6">
+      <div className="max-w-lg mx-auto">
+        <h1 className="text-xl font-semibold text-gray-900 mb-6">
+          Session complete
+        </h1>
+
+        {/* Stat cards */}
+        <div className="grid grid-cols-3 gap-3 mb-6">
+          <StatCard label="Minutes" value={String(summary.total_duration_minutes)} />
+          <StatCard
+            label="Completed"
+            value={`${summary.exercises_completed}/${summary.exercises_total}`}
+          />
+          <StatCard label="Streak" value={`${summary.day_streak} day${summary.day_streak !== 1 ? 's' : ''}`} />
+        </div>
+
+        {/* Ratings breakdown */}
+        <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-4 mb-4">
+          <h2 className="text-sm font-medium text-gray-700 mb-3">
+            How it went
+          </h2>
+          <div className="space-y-2">
+            {ratings.step_forward > 0 && (
+              <RatingRow color="bg-teal-400" label="Step forward" count={ratings.step_forward} />
+            )}
+            {ratings.steady > 0 && (
+              <RatingRow color="bg-gray-400" label="Steady" count={ratings.steady} />
+            )}
+            {ratings.step_back > 0 && (
+              <RatingRow color="bg-amber-400" label="Step back" count={ratings.step_back} />
+            )}
+            {ratings.skipped > 0 && (
+              <RatingRow color="bg-gray-200" label="Skipped" count={ratings.skipped} />
+            )}
+          </div>
+        </div>
+
+        {/* Coaching suggestion */}
+        {coaching_suggestion && (
+          <div className="bg-teal-50 border border-teal-200 rounded-xl p-4 mb-4">
+            <p className="text-sm text-teal-900 leading-relaxed">
+              {coaching_suggestion.text}
+            </p>
+          </div>
+        )}
+
+        {/* Reflection prompt */}
+        {reflection_prompt && !reflectionSaved && (
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-4 mb-4">
+            <p className="text-sm font-medium text-gray-700 mb-1">
+              {reflection_prompt}
+            </p>
+            <p className="text-xs text-gray-400 mb-3">
+              Optional — a moment to notice what you might forget later.
+            </p>
+            <textarea
+              value={reflection}
+              onChange={(e) => setReflection(e.target.value)}
+              placeholder="Felt more relaxed in the left hand. Maybe the new warm-up is helping..."
+              rows={3}
+              className="w-full text-sm text-gray-700 border border-gray-200 rounded-lg px-3 py-2 resize-none focus:outline-none focus:border-primary-400 mb-2"
+            />
+            <button
+              onClick={handleSaveReflection}
+              disabled={!reflection.trim()}
+              className="text-sm text-primary-600 font-medium hover:text-primary-700 disabled:text-gray-400"
+            >
+              Save reflection
+            </button>
+          </div>
+        )}
+        {reflectionSaved && (
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-4 mb-4">
+            <p className="text-sm text-gray-500">Reflection saved.</p>
+          </div>
+        )}
+
+        {/* Actions */}
+        <Link
+          href="/today"
+          className="block w-full text-center py-3 bg-primary-600 text-white rounded-xl font-medium hover:bg-primary-700 transition-colors shadow-sm"
+        >
+          Done
+        </Link>
+      </div>
+    </main>
+  )
+}
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-3 text-center">
+      <p className="text-lg font-semibold text-gray-900">{value}</p>
+      <p className="text-xs text-gray-500">{label}</p>
+    </div>
+  )
+}
+
+function RatingRow({
+  color,
+  label,
+  count,
+}: {
+  color: string
+  label: string
+  count: number
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className={`w-2.5 h-2.5 rounded-full ${color}`} />
+      <span className="text-sm text-gray-600 flex-1">{label}</span>
+      <span className="text-sm text-gray-900 font-medium">{count}</span>
+    </div>
+  )
+}

--- a/frontend/src/app/session/page.tsx
+++ b/frontend/src/app/session/page.tsx
@@ -1,5 +1,0 @@
-import ComingSoonPlaceholder from '@/components/ComingSoonPlaceholder'
-
-export default function SessionPage() {
-  return <ComingSoonPlaceholder title="Active Session" ticketNumber="#145" />
-}

--- a/frontend/src/app/session/start/page.tsx
+++ b/frontend/src/app/session/start/page.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useApi } from '@/lib/useApi'
+import { Suspense } from 'react'
+
+function StartSessionInner() {
+  const api = useApi()
+  const router = useRouter()
+  const params = useSearchParams()
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const instrumentId = params.get('instrument')
+    if (!instrumentId) {
+      setError('Missing instrument parameter')
+      return
+    }
+
+    const templateId = params.get('template')
+    const sessionId = params.get('session')
+
+    const startSession = async () => {
+      try {
+        const log = await api.startPractice({
+          instrument_id: Number(instrumentId),
+          template_id: templateId ? Number(templateId) : undefined,
+          template_session_id: sessionId ? Number(sessionId) : undefined,
+        })
+        router.replace(`/session/${log.id}`)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to start session')
+      }
+    }
+
+    startSession()
+  }, [api, params, router])
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center min-h-[calc(100vh-4rem)] px-6">
+        <div className="text-center">
+          <p className="text-red-600 mb-3">{error}</p>
+          <button
+            onClick={() => router.push('/today')}
+            className="text-primary-600 underline text-sm"
+          >
+            Back to Today
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex items-center justify-center min-h-[calc(100vh-4rem)]">
+      <div className="text-gray-500">Starting session...</div>
+    </div>
+  )
+}
+
+export default function StartSessionPage() {
+  return (
+    <Suspense fallback={
+      <div className="flex items-center justify-center min-h-[calc(100vh-4rem)]">
+        <div className="text-gray-500">Loading...</div>
+      </div>
+    }>
+      <StartSessionInner />
+    </Suspense>
+  )
+}

--- a/frontend/src/components/RatingChevrons.tsx
+++ b/frontend/src/components/RatingChevrons.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import type { Rating } from '@/lib/types'
+
+/**
+ * Directional rating chevrons: step back (-1), steady (0), step forward (1).
+ *
+ * Uses shape + color to encode meaning (accessible to colorblind users):
+ * - Down arrow = step back (amber)
+ * - Horizontal line = steady (gray)
+ * - Up arrow = step forward (teal)
+ */
+export default function RatingChevrons({
+  value,
+  onChange,
+  disabled = false,
+}: {
+  value: Rating | null
+  onChange: (rating: Rating) => void
+  disabled?: boolean
+}) {
+  const buttons: { rating: Rating; label: string; icon: string; activeClass: string }[] = [
+    {
+      rating: -1,
+      label: 'Step back',
+      icon: '↓',
+      activeClass: 'bg-amber-100 text-amber-700 border-amber-300',
+    },
+    {
+      rating: 0,
+      label: 'Steady',
+      icon: '—',
+      activeClass: 'bg-gray-200 text-gray-700 border-gray-400',
+    },
+    {
+      rating: 1,
+      label: 'Step forward',
+      icon: '↑',
+      activeClass: 'bg-teal-100 text-teal-700 border-teal-300',
+    },
+  ]
+
+  return (
+    <div className="flex gap-1">
+      {buttons.map((btn) => {
+        const isActive = value === btn.rating
+        return (
+          <button
+            key={btn.rating}
+            type="button"
+            disabled={disabled}
+            onClick={() => onChange(btn.rating)}
+            aria-label={btn.label}
+            aria-pressed={isActive}
+            className={`w-8 h-8 flex items-center justify-center rounded-full border text-sm font-medium transition-colors ${
+              isActive
+                ? btn.activeClass
+                : 'border-gray-200 text-gray-400 hover:border-gray-300 hover:text-gray-600'
+            } ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+          >
+            {btn.icon}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/components/TimeStepper.tsx
+++ b/frontend/src/components/TimeStepper.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+/**
+ * Compact +/- stepper for section duration. Pre-filled from the plan's
+ * estimated duration. Users adjust in 1-minute increments.
+ */
+export default function TimeStepper({
+  value,
+  onChange,
+  disabled = false,
+}: {
+  value: number
+  onChange: (minutes: number) => void
+  disabled?: boolean
+}) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <button
+        type="button"
+        disabled={disabled || value <= 0}
+        onClick={() => onChange(Math.max(0, value - 1))}
+        className="w-7 h-7 flex items-center justify-center rounded-full border border-gray-200 text-gray-500 text-sm hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed"
+        aria-label="Decrease duration"
+      >
+        −
+      </button>
+      <span className="text-sm text-gray-600 w-12 text-center tabular-nums">
+        {value} min
+      </span>
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => onChange(value + 1)}
+        className="w-7 h-7 flex items-center justify-center rounded-full border border-gray-200 text-gray-500 text-sm hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed"
+        aria-label="Increase duration"
+      >
+        +
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Build the core practice session experience (part 1 of 2 for #145). This PR covers the standard session flow — start, rate, finish. Part 2 adds repertoire block features.

### New routes
- `/session/start` — receives query params from Today tab, starts session via API, redirects to `/session/[id]`
- `/session/[id]` — the main active session screen
- `/session/[id]/summary` — post-session stats, ratings, coaching suggestion, reflection

### New components
- `RatingChevrons` — directional rating (step back / steady / step forward) with color + shape for accessibility
- `TimeStepper` — compact +/- for section duration

### Active session features
- Sticky top bar with session name + abandon action
- Progress bar (completed/total, running time)
- Section cards with time stepper, mark-all-done, skip-section
- Block rows: checkbox, name, last-tempo hint, rating chevrons, expandable notes (auto-save)
- Quick-add block per section
- Add freeform section with type picker
- Session-level notes
- Finish → summary flow

### Session summary
- Stat cards (minutes, completed, streak)
- Ratings breakdown with colored dots
- Coaching suggestion card
- Reflection prompt with save
- "Done" returns to Today

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test` passes
- [ ] Manual: start session from Today tab, rate blocks, finish, see summary
- [ ] Review: hook dependencies, auto-save patterns, error handling
- [ ] Review: component structure for upcoming repertoire additions (part 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
