### PR TITLE
Add template editor — core (#166, part 1 of 2)

### DIFF
--- a/frontend/src/app/plans/[id]/page.tsx
+++ b/frontend/src/app/plans/[id]/page.tsx
@@ -146,13 +146,18 @@ export default function TemplateEditorPage() {
   }
 
   const addSection = async () => {
-    if (!selectedSession) return
-    await api.createSection(selectedSession.id, {
-      name: 'New section',
-      section_type: DEFAULT_SECTION_TYPE,
-      estimated_duration_minutes: 5,
-    })
-    await refresh()
+    if (!selectedSession || busy) return
+    setBusy(true)
+    try {
+      await api.createSection(selectedSession.id, {
+        name: 'New section',
+        section_type: DEFAULT_SECTION_TYPE,
+        estimated_duration_minutes: 5,
+      })
+      await refresh()
+    } finally {
+      setBusy(false)
+    }
   }
 
   const renameSection = async (sectionId: number, name: string) => {
@@ -225,6 +230,7 @@ export default function TemplateEditorPage() {
       router.push(`/plans/${copy.id}`)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to duplicate')
+    } finally {
       setBusy(false)
     }
   }

--- a/frontend/src/app/plans/[id]/page.tsx
+++ b/frontend/src/app/plans/[id]/page.tsx
@@ -32,6 +32,7 @@ export default function TemplateEditorPage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [addBlockSectionId, setAddBlockSectionId] = useState<number | null>(null)
+  const [busy, setBusy] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState<{
     kind: 'template' | 'session' | 'section' | 'block'
     id: number
@@ -66,6 +67,15 @@ export default function TemplateEditorPage() {
   useEffect(() => {
     loadTemplate()
   }, [loadTemplate])
+
+  // Correct selectedSessionId if the session it points at no longer exists
+  // (e.g., another tab deleted it, or a refresh dropped it).
+  useEffect(() => {
+    if (!template) return
+    if (selectedSessionId == null) return
+    if (template.sessions.some((s) => s.id === selectedSessionId)) return
+    setSelectedSessionId(template.sessions[0]?.id ?? null)
+  }, [template, selectedSessionId])
 
   const refresh = useCallback(async () => {
     const t = await api.getTemplate(templateId)
@@ -102,12 +112,17 @@ export default function TemplateEditorPage() {
   }
 
   const addSession = async () => {
-    if (!template) return
-    const next = await api.createTemplateSession(template.id, {
-      name: `Session ${template.sessions.length + 1}`,
-    })
-    setSelectedSessionId(next.id)
-    await refresh()
+    if (!template || busy) return
+    setBusy(true)
+    try {
+      const next = await api.createTemplateSession(template.id, {
+        name: `Session ${template.sessions.length + 1}`,
+      })
+      setSelectedSessionId(next.id)
+      await refresh()
+    } finally {
+      setBusy(false)
+    }
   }
 
   const renameSession = async (sessionId: number, name: string) => {
@@ -201,11 +216,17 @@ export default function TemplateEditorPage() {
   }
 
   const duplicate = async () => {
-    if (!template) return
-    const copy = await api.duplicateTemplate(template.id, {
-      copy_default_spots: true,
-    })
-    router.push(`/plans/${copy.id}`)
+    if (!template || busy) return
+    setBusy(true)
+    try {
+      const copy = await api.duplicateTemplate(template.id, {
+        copy_default_spots: true,
+      })
+      router.push(`/plans/${copy.id}`)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to duplicate')
+      setBusy(false)
+    }
   }
 
   const deleteTemplate = async () => {
@@ -290,7 +311,8 @@ export default function TemplateEditorPage() {
             </button>
             <button
               onClick={duplicate}
-              className="px-3 py-1 rounded-full text-xs border bg-white border-gray-200 text-gray-600"
+              disabled={busy}
+              className="px-3 py-1 rounded-full text-xs border bg-white border-gray-200 text-gray-600 disabled:opacity-50"
             >
               Duplicate
             </button>
@@ -316,6 +338,7 @@ export default function TemplateEditorPage() {
             selectedSessionId={selectedSession?.id ?? null}
             onSelect={setSelectedSessionId}
             onAdd={addSession}
+            addDisabled={busy}
           />
         </div>
 

--- a/frontend/src/app/plans/[id]/page.tsx
+++ b/frontend/src/app/plans/[id]/page.tsx
@@ -1,0 +1,526 @@
+'use client'
+
+import { useEffect, useState, useCallback, useMemo } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import { useApi } from '@/lib/useApi'
+import type {
+  Instrument,
+  Template,
+  TemplateSession,
+  Section,
+  StandardBlockCreate,
+  SectionType,
+} from '@/lib/types'
+import SessionTabs from '@/components/SessionTabs'
+import SectionCard from '@/components/SectionCard'
+import AddBlockSheet from '@/components/AddBlockSheet'
+import ConfirmDialog from '@/components/ConfirmDialog'
+
+// TODO(#168): replace hardcoded section_type with a real picker (template
+// editor + freeform session). All new sections in this PR are 'other'.
+const DEFAULT_SECTION_TYPE: SectionType = 'other'
+
+export default function TemplateEditorPage() {
+  const api = useApi()
+  const params = useParams()
+  const router = useRouter()
+  const templateId = Number(params?.id)
+
+  const [template, setTemplate] = useState<Template | null>(null)
+  const [instrument, setInstrument] = useState<Instrument | null>(null)
+  const [selectedSessionId, setSelectedSessionId] = useState<number | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [addBlockSectionId, setAddBlockSectionId] = useState<number | null>(null)
+  const [confirmDelete, setConfirmDelete] = useState<{
+    kind: 'template' | 'session' | 'section' | 'block'
+    id: number
+    label: string
+  } | null>(null)
+
+  // ---------------------------------------------------------------------
+  // Initial load
+  // ---------------------------------------------------------------------
+  const loadTemplate = useCallback(async () => {
+    if (!Number.isFinite(templateId)) {
+      setError('Invalid plan id')
+      setLoading(false)
+      return
+    }
+    try {
+      setLoading(true)
+      const t = await api.getTemplate(templateId)
+      setTemplate(t)
+      setSelectedSessionId((prev) => prev ?? t.sessions[0]?.id ?? null)
+      const inst = (await api.listInstruments()).find(
+        (i) => i.id === t.instrument_id
+      )
+      setInstrument(inst ?? null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load plan')
+    } finally {
+      setLoading(false)
+    }
+  }, [api, templateId])
+
+  useEffect(() => {
+    loadTemplate()
+  }, [loadTemplate])
+
+  const refresh = useCallback(async () => {
+    const t = await api.getTemplate(templateId)
+    setTemplate(t)
+  }, [api, templateId])
+
+  // ---------------------------------------------------------------------
+  // Derived state
+  // ---------------------------------------------------------------------
+  const selectedSession: TemplateSession | null = useMemo(() => {
+    if (!template) return null
+    return (
+      template.sessions.find((s) => s.id === selectedSessionId) ??
+      template.sessions[0] ??
+      null
+    )
+  }, [template, selectedSessionId])
+
+  const sessionCount = template?.sessions.length ?? 0
+
+  // ---------------------------------------------------------------------
+  // Mutations
+  // ---------------------------------------------------------------------
+  const renameTemplate = async (name: string) => {
+    if (!template || name === template.name) return
+    await api.updateTemplate(template.id, { name })
+    setTemplate({ ...template, name })
+  }
+
+  const setActive = async (isActive: boolean) => {
+    if (!template) return
+    await api.updateTemplate(template.id, { is_active: isActive })
+    setTemplate({ ...template, is_active: isActive })
+  }
+
+  const addSession = async () => {
+    if (!template) return
+    const next = await api.createTemplateSession(template.id, {
+      name: `Session ${template.sessions.length + 1}`,
+    })
+    setSelectedSessionId(next.id)
+    await refresh()
+  }
+
+  const renameSession = async (sessionId: number, name: string) => {
+    await api.updateTemplateSession(sessionId, { name })
+    await refresh()
+  }
+
+  const updateSessionFocus = async (sessionId: number, focus: string) => {
+    await api.updateTemplateSession(sessionId, { focus_description: focus })
+    await refresh()
+  }
+
+  const deleteSession = async (sessionId: number) => {
+    if (!template || template.sessions.length <= 1) return
+    await api.deleteTemplateSession(sessionId)
+    if (selectedSessionId === sessionId) {
+      const remaining = template.sessions.filter((s) => s.id !== sessionId)
+      setSelectedSessionId(remaining[0]?.id ?? null)
+    }
+    await refresh()
+  }
+
+  const addSection = async () => {
+    if (!selectedSession) return
+    await api.createSection(selectedSession.id, {
+      name: 'New section',
+      section_type: DEFAULT_SECTION_TYPE,
+      estimated_duration_minutes: 5,
+    })
+    await refresh()
+  }
+
+  const renameSection = async (sectionId: number, name: string) => {
+    await api.updateSection(sectionId, { name })
+    await refresh()
+  }
+
+  const setSectionDuration = async (sectionId: number, minutes: number) => {
+    await api.updateSection(sectionId, { estimated_duration_minutes: minutes })
+    await refresh()
+  }
+
+  const deleteSection = async (sectionId: number) => {
+    await api.deleteSection(sectionId)
+    await refresh()
+  }
+
+  const moveSection = async (sectionId: number, direction: 'up' | 'down') => {
+    if (!selectedSession) return
+    const ids = selectedSession.sections.map((s) => s.id)
+    const idx = ids.indexOf(sectionId)
+    const swap = direction === 'up' ? idx - 1 : idx + 1
+    if (idx < 0 || swap < 0 || swap >= ids.length) return
+    ;[ids[idx], ids[swap]] = [ids[swap], ids[idx]]
+    await api.reorderSections(selectedSession.id, ids)
+    await refresh()
+  }
+
+  const addBlock = async (sectionId: number, data: StandardBlockCreate) => {
+    await api.createBlock(sectionId, data)
+    await refresh()
+  }
+
+  const renameBlock = async (blockId: number, name: string) => {
+    await api.updateBlock(blockId, { name })
+    await refresh()
+  }
+
+  const setBlockDuration = async (blockId: number, minutes: number) => {
+    await api.updateBlock(blockId, { estimated_duration_minutes: minutes })
+    await refresh()
+  }
+
+  const deleteBlock = async (blockId: number) => {
+    await api.deleteBlock(blockId)
+    await refresh()
+  }
+
+  const moveBlock = async (
+    section: Section,
+    blockId: number,
+    direction: 'up' | 'down'
+  ) => {
+    const ids = section.blocks.map((b) => b.id)
+    const idx = ids.indexOf(blockId)
+    const swap = direction === 'up' ? idx - 1 : idx + 1
+    if (idx < 0 || swap < 0 || swap >= ids.length) return
+    ;[ids[idx], ids[swap]] = [ids[swap], ids[idx]]
+    await api.reorderBlocks(section.id, ids)
+    await refresh()
+  }
+
+  const duplicate = async () => {
+    if (!template) return
+    const copy = await api.duplicateTemplate(template.id, {
+      copy_default_spots: true,
+    })
+    router.push(`/plans/${copy.id}`)
+  }
+
+  const deleteTemplate = async () => {
+    if (!template) return
+    await api.deleteTemplate(template.id)
+    router.push('/plans')
+  }
+
+  // ---------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-gray-500">Loading...</div>
+      </div>
+    )
+  }
+
+  if (error || !template) {
+    return (
+      <div className="flex items-center justify-center min-h-screen px-6">
+        <div className="text-center">
+          <p className="text-red-600 mb-2">{error ?? 'Plan not found'}</p>
+          <button
+            onClick={() => router.push('/plans')}
+            className="text-primary-600 underline text-sm"
+          >
+            Back to plans
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  const addBlockSection = selectedSession?.sections.find(
+    (s) => s.id === addBlockSectionId
+  )
+
+  return (
+    <main className="min-h-screen bg-gray-50">
+      <div className="max-w-lg mx-auto bg-white min-h-screen">
+        {/* Top bar */}
+        <div className="flex items-center justify-between px-4 pt-4 pb-2">
+          <button
+            onClick={() => router.push('/plans')}
+            className="text-sm text-gray-500"
+          >
+            ← Plans
+          </button>
+          <button
+            onClick={() => router.push('/plans')}
+            className="text-sm font-medium text-primary-600"
+          >
+            Done
+          </button>
+        </div>
+
+        {/* Plan header */}
+        <div className="px-4 pt-2 pb-3 border-b border-gray-100">
+          <PlanNameField
+            initial={template.name}
+            onCommit={renameTemplate}
+          />
+          <p className="text-sm text-gray-500 mt-1">
+            {instrument?.name ?? 'Instrument'} ·{' '}
+            {sessionCount === 1
+              ? '1 session'
+              : `${sessionCount}-session rotation`}
+          </p>
+
+          <div className="flex gap-2 mt-3">
+            <button
+              onClick={() => setActive(!template.is_active)}
+              className={`px-3 py-1 rounded-full text-xs border ${
+                template.is_active
+                  ? 'bg-teal-100 border-teal-300 text-teal-700'
+                  : 'bg-white border-gray-200 text-gray-600'
+              }`}
+            >
+              {template.is_active ? 'Active plan ✓' : 'Set as active'}
+            </button>
+            <button
+              onClick={duplicate}
+              className="px-3 py-1 rounded-full text-xs border bg-white border-gray-200 text-gray-600"
+            >
+              Duplicate
+            </button>
+            <button
+              onClick={() =>
+                setConfirmDelete({
+                  kind: 'template',
+                  id: template.id,
+                  label: template.name,
+                })
+              }
+              className="px-3 py-1 rounded-full text-xs border bg-white border-gray-200 text-red-600"
+            >
+              Delete
+            </button>
+          </div>
+        </div>
+
+        {/* Session tabs */}
+        <div className="px-4 pt-3">
+          <SessionTabs
+            sessions={template.sessions}
+            selectedSessionId={selectedSession?.id ?? null}
+            onSelect={setSelectedSessionId}
+            onAdd={addSession}
+          />
+        </div>
+
+        {/* Session body */}
+        {selectedSession && (
+          <div className="px-4 pt-2 pb-6">
+            <SessionFocusField
+              key={selectedSession.id}
+              initial={selectedSession.focus_description ?? ''}
+              onCommit={(value) => updateSessionFocus(selectedSession.id, value)}
+            />
+
+            <SessionRenameRow
+              key={`rename-${selectedSession.id}`}
+              session={selectedSession}
+              canDelete={template.sessions.length > 1}
+              onRename={(name) => renameSession(selectedSession.id, name)}
+              onDelete={() =>
+                setConfirmDelete({
+                  kind: 'session',
+                  id: selectedSession.id,
+                  label: selectedSession.name,
+                })
+              }
+            />
+
+            {/* Sections */}
+            {selectedSession.sections.length === 0 ? (
+              <p className="text-sm text-gray-400 italic mt-4 mb-2">
+                No sections yet.
+              </p>
+            ) : (
+              <div className="mt-3">
+                {selectedSession.sections.map((section, i) => (
+                  <SectionCard
+                    key={section.id}
+                    section={section}
+                    isFirst={i === 0}
+                    isLast={i === selectedSession.sections.length - 1}
+                    onMove={(dir) => moveSection(section.id, dir)}
+                    onRename={(name) => renameSection(section.id, name)}
+                    onDurationChange={(min) =>
+                      setSectionDuration(section.id, min)
+                    }
+                    onDelete={() =>
+                      setConfirmDelete({
+                        kind: 'section',
+                        id: section.id,
+                        label: section.name,
+                      })
+                    }
+                    onAddBlock={() => setAddBlockSectionId(section.id)}
+                    onMoveBlock={(blockId, dir) =>
+                      moveBlock(section, blockId, dir)
+                    }
+                    onRenameBlock={renameBlock}
+                    onChangeBlockDuration={setBlockDuration}
+                    onDeleteBlock={(blockId) => {
+                      const block = section.blocks.find(
+                        (b) => b.id === blockId
+                      )
+                      setConfirmDelete({
+                        kind: 'block',
+                        id: blockId,
+                        label: block?.name ?? block?.piece_name ?? 'block',
+                      })
+                    }}
+                  />
+                ))}
+              </div>
+            )}
+
+            <button
+              onClick={addSection}
+              className="w-full mt-2 py-3 text-sm text-gray-500 border border-dashed border-gray-300 rounded-xl hover:border-primary-300 hover:text-primary-600"
+            >
+              + Add section
+            </button>
+          </div>
+        )}
+
+        {/* Add-block sheet */}
+        {addBlockSection && instrument && (
+          <AddBlockSheet
+            sectionName={addBlockSection.name}
+            instrumentName={instrument.name}
+            instrumentId={instrument.id}
+            onAdd={(data) => addBlock(addBlockSection.id, data)}
+            onClose={() => setAddBlockSectionId(null)}
+          />
+        )}
+
+        {/* Confirm delete */}
+        {confirmDelete && (
+          <ConfirmDialog
+            title={`Delete ${confirmDelete.kind}?`}
+            message={`"${confirmDelete.label}" will be removed.`}
+            confirmLabel="Delete"
+            confirmVariant="danger"
+            onCancel={() => setConfirmDelete(null)}
+            onConfirm={async () => {
+              const c = confirmDelete
+              setConfirmDelete(null)
+              if (c.kind === 'template') await deleteTemplate()
+              else if (c.kind === 'session') await deleteSession(c.id)
+              else if (c.kind === 'section') await deleteSection(c.id)
+              else if (c.kind === 'block') await deleteBlock(c.id)
+            }}
+          />
+        )}
+      </div>
+    </main>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Inline subcomponents
+// ---------------------------------------------------------------------------
+
+function PlanNameField({
+  initial,
+  onCommit,
+}: {
+  initial: string
+  onCommit: (value: string) => void | Promise<void>
+}) {
+  const [value, setValue] = useState(initial)
+  return (
+    <input
+      type="text"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      onBlur={() => {
+        const trimmed = value.trim()
+        if (trimmed && trimmed !== initial) onCommit(trimmed)
+        else if (!trimmed) setValue(initial)
+      }}
+      placeholder="Plan name"
+      className="w-full text-xl font-semibold text-gray-900 bg-transparent placeholder-gray-300 focus:outline-none"
+    />
+  )
+}
+
+function SessionFocusField({
+  initial,
+  onCommit,
+}: {
+  initial: string
+  onCommit: (value: string) => void | Promise<void>
+}) {
+  const [value, setValue] = useState(initial)
+  return (
+    <div className="mt-3">
+      <label className="block text-xs text-gray-500 mb-1">
+        Session focus (shown on Today tab)
+      </label>
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onBlur={() => {
+          if (value !== initial) onCommit(value)
+        }}
+        placeholder="e.g. Intonation and bow control"
+        className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-primary-300"
+      />
+    </div>
+  )
+}
+
+function SessionRenameRow({
+  session,
+  canDelete,
+  onRename,
+  onDelete,
+}: {
+  session: TemplateSession
+  canDelete: boolean
+  onRename: (name: string) => void | Promise<void>
+  onDelete: () => void
+}) {
+  const [name, setName] = useState(session.name)
+  return (
+    <div className="mt-3 flex items-center gap-2">
+      <label className="block text-xs text-gray-500 shrink-0">Name</label>
+      <input
+        type="text"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        onBlur={() => {
+          const trimmed = name.trim()
+          if (trimmed && trimmed !== session.name) onRename(trimmed)
+          else if (!trimmed) setName(session.name)
+        }}
+        className="flex-1 px-3 py-1.5 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-primary-300"
+      />
+      {canDelete && (
+        <button
+          onClick={onDelete}
+          className="shrink-0 px-2 py-1 text-xs text-red-500"
+        >
+          Delete session
+        </button>
+      )}
+    </div>
+  )
+}
+

--- a/frontend/src/app/plans/page.tsx
+++ b/frontend/src/app/plans/page.tsx
@@ -1,5 +1,182 @@
-import ComingSoonPlaceholder from '@/components/ComingSoonPlaceholder'
+'use client'
+
+import { useEffect, useState, useCallback } from 'react'
+import { useRouter } from 'next/navigation'
+import { useApi } from '@/lib/useApi'
+import type { Instrument, TemplateListItem } from '@/lib/types'
 
 export default function PlansPage() {
-  return <ComingSoonPlaceholder title="Plans" ticketNumber="#147" />
+  const api = useApi()
+  const router = useRouter()
+  const [instruments, setInstruments] = useState<Instrument[]>([])
+  const [selectedInstrumentId, setSelectedInstrumentId] = useState<number | null>(null)
+  const [templates, setTemplates] = useState<TemplateListItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [creating, setCreating] = useState(false)
+
+  const loadInstruments = useCallback(async () => {
+    try {
+      setLoading(true)
+      const list = await api.listInstruments()
+      setInstruments(list)
+      setSelectedInstrumentId((prev) => prev ?? list[0]?.id ?? null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load instruments')
+    } finally {
+      setLoading(false)
+    }
+  }, [api])
+
+  const loadTemplates = useCallback(
+    async (instrumentId: number) => {
+      try {
+        const list = await api.listTemplates(instrumentId)
+        setTemplates(list)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load plans')
+      }
+    },
+    [api]
+  )
+
+  useEffect(() => {
+    loadInstruments()
+  }, [loadInstruments])
+
+  useEffect(() => {
+    if (selectedInstrumentId != null) loadTemplates(selectedInstrumentId)
+  }, [selectedInstrumentId, loadTemplates])
+
+  const handleCreate = async () => {
+    if (selectedInstrumentId == null || creating) return
+    setCreating(true)
+    try {
+      const template = await api.createTemplate(selectedInstrumentId, {
+        name: 'New plan',
+      })
+      // Seed the template with a first session so the editor has something to render.
+      await api.createTemplateSession(template.id, { name: 'Session 1' })
+      router.push(`/plans/${template.id}`)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create plan')
+      setCreating(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-gray-500">Loading...</div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center min-h-screen px-6">
+        <div className="text-center">
+          <p className="text-red-600 mb-2">{error}</p>
+          <button
+            onClick={loadInstruments}
+            className="text-primary-600 underline text-sm"
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  if (instruments.length === 0) {
+    return (
+      <main className="min-h-screen bg-gray-50 px-4 pt-6">
+        <div className="max-w-lg mx-auto text-center mt-16">
+          <p className="text-gray-500">Add an instrument to start planning.</p>
+        </div>
+      </main>
+    )
+  }
+
+  const showInstrumentToggle = instruments.length > 1
+
+  return (
+    <main className="min-h-screen bg-gray-50 px-4 pt-6">
+      <div className="max-w-lg mx-auto">
+        <div className="flex items-center justify-between mb-4">
+          <h1 className="text-2xl font-semibold text-gray-900">Plans</h1>
+          <button
+            onClick={handleCreate}
+            disabled={creating}
+            className="px-4 py-2 bg-primary-600 text-white rounded-lg text-sm font-medium hover:bg-primary-700 disabled:opacity-50"
+          >
+            New plan
+          </button>
+        </div>
+
+        {showInstrumentToggle && (
+          <div className="flex gap-2 mb-4 overflow-x-auto pb-1">
+            {instruments.map((inst) => {
+              const active = inst.id === selectedInstrumentId
+              return (
+                <button
+                  key={inst.id}
+                  onClick={() => setSelectedInstrumentId(inst.id)}
+                  className={`px-3 py-1.5 rounded-full text-sm whitespace-nowrap border transition-colors ${
+                    active
+                      ? 'bg-primary-100 border-primary-300 text-primary-800'
+                      : 'bg-white border-gray-200 text-gray-600'
+                  }`}
+                >
+                  {inst.name}
+                </button>
+              )
+            })}
+          </div>
+        )}
+
+        {templates.length === 0 ? (
+          <div className="bg-white rounded-xl border border-gray-200 p-8 text-center">
+            <p className="text-gray-500 text-sm mb-4">No plans yet.</p>
+            <button
+              onClick={handleCreate}
+              disabled={creating}
+              className="px-4 py-2 bg-primary-600 text-white rounded-lg text-sm font-medium hover:bg-primary-700 disabled:opacity-50"
+            >
+              Create your first plan
+            </button>
+          </div>
+        ) : (
+          <ul className="space-y-2">
+            {templates.map((t) => (
+              <li key={t.id}>
+                <button
+                  onClick={() => router.push(`/plans/${t.id}`)}
+                  className="w-full text-left bg-white rounded-xl border border-gray-200 p-4 hover:border-primary-300 transition-colors"
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="min-w-0">
+                      <p className="font-medium text-gray-900 truncate">
+                        {t.name}
+                      </p>
+                      {t.description && (
+                        <p className="text-sm text-gray-500 truncate">
+                          {t.description}
+                        </p>
+                      )}
+                    </div>
+                    {t.is_active && (
+                      <span className="shrink-0 px-2 py-0.5 bg-teal-100 text-teal-700 text-xs rounded-full">
+                        Active
+                      </span>
+                    )}
+                  </div>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </main>
+  )
 }

--- a/frontend/src/components/AddBlockSheet.tsx
+++ b/frontend/src/components/AddBlockSheet.tsx
@@ -1,0 +1,243 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useApi } from '@/lib/useApi'
+import type {
+  CuratedBlock,
+  RecentBlock,
+  StandardBlockCreate,
+} from '@/lib/types'
+
+type Tab = 'curated' | 'recent' | 'repertoire'
+
+/**
+ * Bottom-sheet block library for adding a block to a section.
+ *
+ * Repertoire tab is stubbed in this PR (empty state); the full flow lands in
+ * #167 along with the spot management drawer.
+ */
+export default function AddBlockSheet({
+  sectionName,
+  instrumentName,
+  instrumentId,
+  onAdd,
+  onClose,
+}: {
+  sectionName: string
+  instrumentName: string
+  instrumentId: number
+  onAdd: (data: StandardBlockCreate) => Promise<void>
+  onClose: () => void
+}) {
+  const api = useApi()
+  const [tab, setTab] = useState<Tab>('curated')
+  const [query, setQuery] = useState('')
+  const [curated, setCurated] = useState<CuratedBlock[]>([])
+  const [recent, setRecent] = useState<RecentBlock[]>([])
+  const [loading, setLoading] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    if (tab === 'curated') {
+      setLoading(true)
+      api
+        .browseCuratedBlocks({
+          instrument: instrumentName.toLowerCase(),
+          q: query || undefined,
+        })
+        .then(setCurated)
+        .catch(() => setCurated([]))
+        .finally(() => setLoading(false))
+    } else if (tab === 'recent') {
+      setLoading(true)
+      api
+        .listRecentBlocks(instrumentId, 25)
+        .then(setRecent)
+        .catch(() => setRecent([]))
+        .finally(() => setLoading(false))
+    }
+  }, [tab, query, api, instrumentName, instrumentId])
+
+  const submit = async (data: StandardBlockCreate) => {
+    if (submitting) return
+    setSubmitting(true)
+    try {
+      await onAdd(data)
+      onClose()
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleAddCustom = () => {
+    const name = query.trim()
+    if (!name) return
+    submit({ name })
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/40">
+      <div className="w-full max-w-lg bg-white rounded-t-2xl shadow-xl flex flex-col max-h-[85vh]">
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 pt-4 pb-2 border-b border-gray-100">
+          <p className="text-sm text-gray-500">Add to: {sectionName}</p>
+          <button
+            onClick={onClose}
+            className="text-sm text-gray-500 hover:text-gray-800"
+          >
+            Cancel
+          </button>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex gap-1 px-4 pt-3">
+          {(['curated', 'recent', 'repertoire'] as Tab[]).map((t) => (
+            <button
+              key={t}
+              onClick={() => setTab(t)}
+              className={`px-3 py-1.5 rounded-full text-sm border ${
+                tab === t
+                  ? 'bg-gray-900 text-white border-gray-900'
+                  : 'bg-white border-gray-200 text-gray-600'
+              }`}
+            >
+              {t === 'curated' ? 'Curated' : t === 'recent' ? 'Recent' : 'Your rep.'}
+            </button>
+          ))}
+        </div>
+
+        {/* Search (curated only) */}
+        {tab === 'curated' && (
+          <div className="px-4 pt-3">
+            <input
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search blocks or type your own..."
+              className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-primary-300"
+            />
+          </div>
+        )}
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto px-4 py-3">
+          {tab === 'curated' && (
+            <CuratedList
+              blocks={curated}
+              loading={loading}
+              onPick={(b) =>
+                submit({
+                  name: b.name,
+                  curated_block_id: b.id,
+                  description: b.description ?? undefined,
+                  estimated_duration_minutes: b.default_duration_minutes,
+                })
+              }
+            />
+          )}
+          {tab === 'recent' && (
+            <RecentList
+              blocks={recent}
+              loading={loading}
+              onPick={(b) =>
+                submit({
+                  name: b.name,
+                  curated_block_id: b.curated_block_id ?? undefined,
+                })
+              }
+            />
+          )}
+          {tab === 'repertoire' && (
+            <div className="py-12 text-center text-sm text-gray-400">
+              <p>Repertoire blocks coming soon.</p>
+              <p className="text-xs mt-1">Tracked in #167.</p>
+            </div>
+          )}
+        </div>
+
+        {/* Custom add (curated tab) */}
+        {tab === 'curated' && query.trim().length > 0 && (
+          <div className="border-t border-gray-100 px-4 py-3">
+            <button
+              onClick={handleAddCustom}
+              disabled={submitting}
+              className="w-full px-3 py-2 bg-primary-600 text-white rounded-lg text-sm font-medium hover:bg-primary-700 disabled:opacity-50"
+            >
+              Add &quot;{query.trim()}&quot;
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function CuratedList({
+  blocks,
+  loading,
+  onPick,
+}: {
+  blocks: CuratedBlock[]
+  loading: boolean
+  onPick: (b: CuratedBlock) => void
+}) {
+  if (loading) return <p className="text-center text-sm text-gray-400 py-8">Loading...</p>
+  if (blocks.length === 0) {
+    return (
+      <p className="text-center text-sm text-gray-400 py-8">
+        No matches. Type a name and tap Add to create your own.
+      </p>
+    )
+  }
+  return (
+    <ul className="space-y-1">
+      {blocks.map((b) => (
+        <li key={b.id}>
+          <button
+            onClick={() => onPick(b)}
+            className="w-full text-left flex items-center justify-between gap-3 px-2 py-2 rounded-lg hover:bg-gray-50"
+          >
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-gray-900 truncate">{b.name}</p>
+              {b.description && (
+                <p className="text-xs text-gray-500 truncate">{b.description}</p>
+              )}
+            </div>
+            <span className="shrink-0 text-xs text-gray-400 tabular-nums">
+              {b.usage_percentage}%
+            </span>
+          </button>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function RecentList({
+  blocks,
+  loading,
+  onPick,
+}: {
+  blocks: RecentBlock[]
+  loading: boolean
+  onPick: (b: RecentBlock) => void
+}) {
+  if (loading) return <p className="text-center text-sm text-gray-400 py-8">Loading...</p>
+  if (blocks.length === 0) {
+    return <p className="text-center text-sm text-gray-400 py-8">No recent blocks yet.</p>
+  }
+  return (
+    <ul className="space-y-1">
+      {blocks.map((b, i) => (
+        <li key={`${b.name}-${b.last_used_at}-${i}`}>
+          <button
+            onClick={() => onPick(b)}
+            className="w-full text-left px-2 py-2 rounded-lg hover:bg-gray-50"
+          >
+            <p className="text-sm font-medium text-gray-900 truncate">{b.name}</p>
+          </button>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/frontend/src/components/AddBlockSheet.tsx
+++ b/frontend/src/components/AddBlockSheet.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useApi } from '@/lib/useApi'
 import type {
   CuratedBlock,
@@ -36,6 +36,22 @@ export default function AddBlockSheet({
   const [recent, setRecent] = useState<RecentBlock[]>([])
   const [loading, setLoading] = useState(false)
   const [submitting, setSubmitting] = useState(false)
+  const closeButtonRef = useRef<HTMLButtonElement>(null)
+
+  // Lock body scroll while open and close on Escape.
+  useEffect(() => {
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKey)
+    closeButtonRef.current?.focus()
+    return () => {
+      document.body.style.overflow = previousOverflow
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [onClose])
 
   useEffect(() => {
     if (tab === 'curated') {
@@ -76,14 +92,26 @@ export default function AddBlockSheet({
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/40">
-      <div className="w-full max-w-lg bg-white rounded-t-2xl shadow-xl flex flex-col max-h-[85vh]">
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center bg-black/40"
+      role="presentation"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Add block to ${sectionName}`}
+        className="w-full max-w-lg bg-white rounded-t-2xl shadow-xl flex flex-col max-h-[85vh]"
+      >
         {/* Header */}
         <div className="flex items-center justify-between px-4 pt-4 pb-2 border-b border-gray-100">
           <p className="text-sm text-gray-500">Add to: {sectionName}</p>
           <button
+            ref={closeButtonRef}
             onClick={onClose}
-            className="text-sm text-gray-500 hover:text-gray-800"
+            className="text-sm text-gray-500 hover:text-gray-800 px-2 py-1 touch-manipulation"
           >
             Cancel
           </button>

--- a/frontend/src/components/AddBlockSheet.tsx
+++ b/frontend/src/components/AddBlockSheet.tsx
@@ -37,13 +37,18 @@ export default function AddBlockSheet({
   const [loading, setLoading] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const closeButtonRef = useRef<HTMLButtonElement>(null)
+  const onCloseRef = useRef(onClose)
+  useEffect(() => {
+    onCloseRef.current = onClose
+  }, [onClose])
 
-  // Lock body scroll while open and close on Escape.
+  // Lock body scroll while open and close on Escape. Mount-only effect so
+  // parent re-renders don't re-fire focus/scroll-lock setup.
   useEffect(() => {
     const previousOverflow = document.body.style.overflow
     document.body.style.overflow = 'hidden'
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose()
+      if (e.key === 'Escape') onCloseRef.current()
     }
     document.addEventListener('keydown', onKey)
     closeButtonRef.current?.focus()
@@ -51,7 +56,7 @@ export default function AddBlockSheet({
       document.body.style.overflow = previousOverflow
       document.removeEventListener('keydown', onKey)
     }
-  }, [onClose])
+  }, [])
 
   useEffect(() => {
     if (tab === 'curated') {

--- a/frontend/src/components/BlockRow.tsx
+++ b/frontend/src/components/BlockRow.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { useState } from 'react'
+import type { Block } from '@/lib/types'
+import TimeStepper from './TimeStepper'
+
+/**
+ * Standard (non-repertoire) block row in the template editor.
+ *
+ * Repertoire blocks (piece_id != null) are rendered by a separate component
+ * landing in #167 — for now this row falls back to displaying piece_name if it
+ * encounters one, but does not attempt the spot-management drawer.
+ */
+export default function BlockRow({
+  block,
+  isFirst,
+  isLast,
+  onMove,
+  onRename,
+  onDurationChange,
+  onDelete,
+}: {
+  block: Block
+  isFirst: boolean
+  isLast: boolean
+  onMove: (direction: 'up' | 'down') => void
+  onRename: (name: string) => void
+  onDurationChange: (minutes: number) => void
+  onDelete: () => void
+}) {
+  const [name, setName] = useState(block.name ?? block.piece_name ?? '')
+  const isRepertoire = block.piece_id != null
+
+  const handleBlur = () => {
+    const trimmed = name.trim()
+    const original = block.name ?? block.piece_name ?? ''
+    if (trimmed && trimmed !== original) onRename(trimmed)
+    else if (!trimmed) setName(original)
+  }
+
+  return (
+    <div className="flex items-center gap-2 px-3 py-2 border-b border-gray-100 last:border-b-0">
+      {/* Reorder chevrons */}
+      <div className="flex flex-col gap-0.5 shrink-0">
+        <button
+          type="button"
+          disabled={isFirst}
+          onClick={() => onMove('up')}
+          className="w-5 h-3 flex items-center justify-center text-gray-400 hover:text-gray-700 disabled:opacity-25 disabled:cursor-not-allowed text-xs"
+          aria-label="Move up"
+        >
+          ▲
+        </button>
+        <button
+          type="button"
+          disabled={isLast}
+          onClick={() => onMove('down')}
+          className="w-5 h-3 flex items-center justify-center text-gray-400 hover:text-gray-700 disabled:opacity-25 disabled:cursor-not-allowed text-xs"
+          aria-label="Move down"
+        >
+          ▼
+        </button>
+      </div>
+
+      {/* Name */}
+      <input
+        type="text"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        onBlur={handleBlur}
+        disabled={isRepertoire}
+        placeholder="Block name"
+        className="flex-1 min-w-0 bg-transparent text-sm text-gray-800 placeholder-gray-400 focus:outline-none disabled:text-gray-500"
+      />
+
+      {/* Time stepper */}
+      <TimeStepper
+        value={block.estimated_duration_minutes ?? 0}
+        onChange={onDurationChange}
+      />
+
+      {/* Delete */}
+      <button
+        type="button"
+        onClick={onDelete}
+        className="shrink-0 w-6 h-6 flex items-center justify-center text-gray-300 hover:text-red-500 text-sm"
+        aria-label="Remove block"
+      >
+        ✕
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/components/BlockRow.tsx
+++ b/frontend/src/components/BlockRow.tsx
@@ -41,12 +41,12 @@ export default function BlockRow({
   return (
     <div className="flex items-center gap-2 px-3 py-2 border-b border-gray-100 last:border-b-0">
       {/* Reorder chevrons */}
-      <div className="flex flex-col gap-0.5 shrink-0">
+      <div className="flex flex-col shrink-0">
         <button
           type="button"
           disabled={isFirst}
           onClick={() => onMove('up')}
-          className="w-5 h-3 flex items-center justify-center text-gray-400 hover:text-gray-700 disabled:opacity-25 disabled:cursor-not-allowed text-xs"
+          className="w-9 h-6 flex items-center justify-center text-gray-400 hover:text-gray-700 disabled:opacity-25 disabled:cursor-not-allowed text-xs touch-manipulation"
           aria-label="Move up"
         >
           ▲
@@ -55,7 +55,7 @@ export default function BlockRow({
           type="button"
           disabled={isLast}
           onClick={() => onMove('down')}
-          className="w-5 h-3 flex items-center justify-center text-gray-400 hover:text-gray-700 disabled:opacity-25 disabled:cursor-not-allowed text-xs"
+          className="w-9 h-6 flex items-center justify-center text-gray-400 hover:text-gray-700 disabled:opacity-25 disabled:cursor-not-allowed text-xs touch-manipulation"
           aria-label="Move down"
         >
           ▼
@@ -83,7 +83,7 @@ export default function BlockRow({
       <button
         type="button"
         onClick={onDelete}
-        className="shrink-0 w-6 h-6 flex items-center justify-center text-gray-300 hover:text-red-500 text-sm"
+        className="shrink-0 w-9 h-9 flex items-center justify-center text-gray-300 hover:text-red-500 text-sm touch-manipulation"
         aria-label="Remove block"
       >
         ✕

--- a/frontend/src/components/SectionCard.tsx
+++ b/frontend/src/components/SectionCard.tsx
@@ -1,0 +1,133 @@
+'use client'
+
+import { useState } from 'react'
+import type { Section } from '@/lib/types'
+import BlockRow from './BlockRow'
+
+export default function SectionCard({
+  section,
+  isFirst,
+  isLast,
+  onMove,
+  onRename,
+  onDurationChange,
+  onDelete,
+  onAddBlock,
+  onMoveBlock,
+  onRenameBlock,
+  onChangeBlockDuration,
+  onDeleteBlock,
+}: {
+  section: Section
+  isFirst: boolean
+  isLast: boolean
+  onMove: (direction: 'up' | 'down') => void
+  onRename: (name: string) => void
+  onDurationChange: (minutes: number) => void
+  onDelete: () => void
+  onAddBlock: () => void
+  onMoveBlock: (blockId: number, direction: 'up' | 'down') => void
+  onRenameBlock: (blockId: number, name: string) => void
+  onChangeBlockDuration: (blockId: number, minutes: number) => void
+  onDeleteBlock: (blockId: number) => void
+}) {
+  const [name, setName] = useState(section.name)
+  const [duration, setDuration] = useState(
+    String(section.estimated_duration_minutes)
+  )
+
+  const handleNameBlur = () => {
+    const trimmed = name.trim()
+    if (trimmed && trimmed !== section.name) onRename(trimmed)
+    else if (!trimmed) setName(section.name)
+  }
+
+  const handleDurationBlur = () => {
+    const parsed = Math.max(0, parseInt(duration, 10) || 0)
+    if (parsed !== section.estimated_duration_minutes) onDurationChange(parsed)
+    setDuration(String(parsed))
+  }
+
+  return (
+    <section className="bg-white rounded-xl border border-gray-200 mb-3 overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center gap-2 px-3 py-2 bg-gray-50 border-b border-gray-200">
+        <div className="flex flex-col gap-0.5 shrink-0">
+          <button
+            type="button"
+            disabled={isFirst}
+            onClick={() => onMove('up')}
+            className="w-5 h-3 flex items-center justify-center text-gray-400 hover:text-gray-700 disabled:opacity-25 disabled:cursor-not-allowed text-xs"
+            aria-label="Move section up"
+          >
+            ▲
+          </button>
+          <button
+            type="button"
+            disabled={isLast}
+            onClick={() => onMove('down')}
+            className="w-5 h-3 flex items-center justify-center text-gray-400 hover:text-gray-700 disabled:opacity-25 disabled:cursor-not-allowed text-xs"
+            aria-label="Move section down"
+          >
+            ▼
+          </button>
+        </div>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          onBlur={handleNameBlur}
+          placeholder="Section name"
+          className="flex-1 min-w-0 bg-transparent text-sm font-medium text-gray-800 placeholder-gray-400 focus:outline-none"
+        />
+        <input
+          type="number"
+          min={0}
+          value={duration}
+          onChange={(e) => setDuration(e.target.value)}
+          onBlur={handleDurationBlur}
+          className="w-12 bg-transparent text-sm text-gray-500 text-right tabular-nums focus:outline-none"
+          aria-label="Section duration in minutes"
+        />
+        <span className="text-xs text-gray-400">min</span>
+        <button
+          type="button"
+          onClick={onDelete}
+          className="shrink-0 w-6 h-6 flex items-center justify-center text-gray-300 hover:text-red-500 text-sm"
+          aria-label="Remove section"
+        >
+          ✕
+        </button>
+      </div>
+
+      {/* Blocks */}
+      {section.blocks.length === 0 ? (
+        <p className="px-4 py-3 text-xs text-gray-400 italic">No blocks yet.</p>
+      ) : (
+        <ul>
+          {section.blocks.map((b, i) => (
+            <li key={b.id}>
+              <BlockRow
+                block={b}
+                isFirst={i === 0}
+                isLast={i === section.blocks.length - 1}
+                onMove={(dir) => onMoveBlock(b.id, dir)}
+                onRename={(name) => onRenameBlock(b.id, name)}
+                onDurationChange={(min) => onChangeBlockDuration(b.id, min)}
+                onDelete={() => onDeleteBlock(b.id)}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <button
+        type="button"
+        onClick={onAddBlock}
+        className="w-full py-2.5 text-sm text-primary-600 border-t border-gray-100 hover:bg-gray-50"
+      >
+        + Add block
+      </button>
+    </section>
+  )
+}

--- a/frontend/src/components/SectionCard.tsx
+++ b/frontend/src/components/SectionCard.tsx
@@ -52,12 +52,12 @@ export default function SectionCard({
     <section className="bg-white rounded-xl border border-gray-200 mb-3 overflow-hidden">
       {/* Header */}
       <div className="flex items-center gap-2 px-3 py-2 bg-gray-50 border-b border-gray-200">
-        <div className="flex flex-col gap-0.5 shrink-0">
+        <div className="flex flex-col shrink-0">
           <button
             type="button"
             disabled={isFirst}
             onClick={() => onMove('up')}
-            className="w-5 h-3 flex items-center justify-center text-gray-400 hover:text-gray-700 disabled:opacity-25 disabled:cursor-not-allowed text-xs"
+            className="w-9 h-6 flex items-center justify-center text-gray-400 hover:text-gray-700 disabled:opacity-25 disabled:cursor-not-allowed text-xs touch-manipulation"
             aria-label="Move section up"
           >
             ▲
@@ -66,7 +66,7 @@ export default function SectionCard({
             type="button"
             disabled={isLast}
             onClick={() => onMove('down')}
-            className="w-5 h-3 flex items-center justify-center text-gray-400 hover:text-gray-700 disabled:opacity-25 disabled:cursor-not-allowed text-xs"
+            className="w-9 h-6 flex items-center justify-center text-gray-400 hover:text-gray-700 disabled:opacity-25 disabled:cursor-not-allowed text-xs touch-manipulation"
             aria-label="Move section down"
           >
             ▼
@@ -93,7 +93,7 @@ export default function SectionCard({
         <button
           type="button"
           onClick={onDelete}
-          className="shrink-0 w-6 h-6 flex items-center justify-center text-gray-300 hover:text-red-500 text-sm"
+          className="shrink-0 w-9 h-9 flex items-center justify-center text-gray-300 hover:text-red-500 text-sm touch-manipulation"
           aria-label="Remove section"
         >
           ✕

--- a/frontend/src/components/SessionTabs.tsx
+++ b/frontend/src/components/SessionTabs.tsx
@@ -7,11 +7,13 @@ export default function SessionTabs({
   selectedSessionId,
   onSelect,
   onAdd,
+  addDisabled = false,
 }: {
   sessions: TemplateSession[]
   selectedSessionId: number | null
   onSelect: (id: number) => void
   onAdd: () => void
+  addDisabled?: boolean
 }) {
   return (
     <div className="flex gap-2 overflow-x-auto pb-2 -mx-1 px-1">
@@ -33,7 +35,8 @@ export default function SessionTabs({
       })}
       <button
         onClick={onAdd}
-        className="shrink-0 w-8 h-8 rounded-full border border-dashed border-gray-300 text-gray-400 text-sm flex items-center justify-center hover:border-primary-300 hover:text-primary-600"
+        disabled={addDisabled}
+        className="shrink-0 w-9 h-9 rounded-full border border-dashed border-gray-300 text-gray-400 text-sm flex items-center justify-center hover:border-primary-300 hover:text-primary-600 disabled:opacity-50 touch-manipulation"
         aria-label="Add session"
       >
         +

--- a/frontend/src/components/SessionTabs.tsx
+++ b/frontend/src/components/SessionTabs.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import type { TemplateSession } from '@/lib/types'
+
+export default function SessionTabs({
+  sessions,
+  selectedSessionId,
+  onSelect,
+  onAdd,
+}: {
+  sessions: TemplateSession[]
+  selectedSessionId: number | null
+  onSelect: (id: number) => void
+  onAdd: () => void
+}) {
+  return (
+    <div className="flex gap-2 overflow-x-auto pb-2 -mx-1 px-1">
+      {sessions.map((s) => {
+        const active = s.id === selectedSessionId
+        return (
+          <button
+            key={s.id}
+            onClick={() => onSelect(s.id)}
+            className={`px-3 py-1.5 rounded-full text-sm whitespace-nowrap border transition-colors ${
+              active
+                ? 'bg-primary-100 border-primary-300 text-primary-800'
+                : 'bg-white border-gray-200 text-gray-600'
+            }`}
+          >
+            {s.name}
+          </button>
+        )
+      })}
+      <button
+        onClick={onAdd}
+        className="shrink-0 w-8 h-8 rounded-full border border-dashed border-gray-300 text-gray-400 text-sm flex items-center justify-center hover:border-primary-300 hover:text-primary-600"
+        aria-label="Add session"
+      >
+        +
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Replaces `/plans` placeholder with a list + editor for practice plans. Closes #166 (the core slice of #147).

Repertoire blocks and the spot management drawer are out of scope — tracked in #167.

## What's wired up

**Plans list (`/plans`)**
- Instrument toggle (when there's more than one)
- New plan button (creates a template + a default Session 1)
- Active plan indicator
- Tap a plan to enter the editor

**Editor (`/plans/[id]`)**
- Plan name (autosave on blur)
- Instrument · session-count subtitle
- Set-as-active / Duplicate / Delete actions
- Session tabs (add, switch, rename, delete; last session protected)
- Session focus field (shown on Today tab)
- Section cards: name, duration, reorder via ▲▼, add/remove blocks
- Block rows: name, duration via `TimeStepper`, reorder via ▲▼, delete
- Add-block sheet with **Curated** (search + usage-percentage), **Recent**, and a **Your rep.** stub pointing at #167
- Free-text block creation when there are no curated matches
- All deletes go through `ConfirmDialog`

## Deferred

- Repertoire blocks anywhere in the editor → **#167**
- Spot management drawer → **#167**
- "Your repertoire" tab content → **#167**
- Section type picker — `section_type` hardcoded to `'other'` with `TODO(#168)` → **#168** (design ticket)
- Real drag-and-drop reorder — chevrons for now; if mobile use feels janky, we can swap to `dnd-kit` in a follow-up

## Verified

- `npx tsc --noEmit` ✓
- `npm run lint` ✓
- `npm test` ✓
- `npm run build` ✓
- Browser interaction not yet user-verified — touch-feel of chevron reorder, sheet layout on phone widths, and rapid-tap autosave races still need real-device confirmation

## Test plan

- [ ] Create a new plan from the Plans list
- [ ] Rename the plan, verify autosave on blur
- [ ] Add / rename / reorder / delete sections
- [ ] Add a curated block via search
- [ ] Add a custom block via free-text
- [ ] Add a recent block
- [ ] Reorder blocks with ▲▼
- [ ] Edit block duration via the TimeStepper
- [ ] Delete a block — confirm dialog appears
- [ ] Add a new session, switch tabs, edit per-session focus
- [ ] Delete a non-last session (last-session delete should be hidden)
- [ ] Set plan as active, verify the badge in the list
- [ ] Duplicate a plan, verify it routes to the new copy
- [ ] Delete a plan from the editor — returns to list

🤖 Generated with [Claude Code](https://claude.com/claude-code)
