### PR TITLE
Pass NEXT_PUBLIC_* as Docker build args in compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,16 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
+      args:
+        # NEXT_PUBLIC_* must be passed as build args so the static export in
+        # `npm run build` (run inside the Dockerfile) can inline them.
+        # Runtime `environment:` vars below don't reach the build stage.
+        NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}
+        NEXT_PUBLIC_CLERK_SIGN_IN_URL: /sign-in
+        NEXT_PUBLIC_CLERK_SIGN_UP_URL: /sign-up
+        NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL: /
+        NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL: /
+        NEXT_PUBLIC_API_URL: http://localhost:8000
     ports:
       - "3000:3000"
     dns:


### PR DESCRIPTION
## Summary

Local `docker compose build` was failing with every static page erroring during Next.js export. Root cause: the frontend Dockerfile declares `NEXT_PUBLIC_*` as build `ARG`s (because Next.js inlines them at build time during static prerender), but `docker-compose.yml` only sets them as runtime `environment:` vars — those don't reach the build stage.

Without `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` at build time, `<ClerkProvider>` in `app/layout.tsx` throws during static prerender and the entire export fails.

Railway already worked because `frontend/railway.toml` properly maps these as `[build.args]`. This PR mirrors that on the local compose side.

## Test plan

- [ ] `docker compose build frontend` succeeds (with `.env` populated at the repo root)
- [ ] `docker compose up` brings the frontend up and you can sign in
- [ ] No regression in the existing Railway deploy (this only touches `docker-compose.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
