### PR TITLE
Phase 0 PR 2 — Theme provider + dark mode wiring

### DIFF
--- a/frontend/src/app/(app)/profile/page.tsx
+++ b/frontend/src/app/(app)/profile/page.tsx
@@ -1,5 +1,86 @@
-import ComingSoonPlaceholder from '@/components/ComingSoonPlaceholder'
+'use client'
+
+import { Monitor, Sun, Moon } from 'lucide-react'
+import { useTheme } from '@/hooks/useTheme'
+import type { ThemePreference } from '@/components/ThemeProvider'
+
+const OPTIONS: Array<{
+  value: ThemePreference
+  label: string
+  Icon: typeof Monitor
+}> = [
+  { value: 'system', label: 'Match system', Icon: Monitor },
+  { value: 'light', label: 'Light', Icon: Sun },
+  { value: 'dark', label: 'Dark', Icon: Moon },
+]
+
+function ThemePicker() {
+  const { theme, setTheme } = useTheme()
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Appearance"
+      className="flex gap-sm flex-wrap"
+    >
+      {OPTIONS.map(({ value, label, Icon }) => {
+        const active = theme === value
+        return (
+          <button
+            key={value}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            onClick={() => setTheme(value)}
+            className={`inline-flex items-center gap-sm rounded-md text-xs font-medium transition-colors ${
+              active
+                ? 'bg-pill-active-bg text-pill-active-text border border-pill-active-bg'
+                : 'border border-pill-inactive-border text-pill-inactive-text hover:text-text-primary'
+            }`}
+            style={{ padding: '5px 14px' }}
+          >
+            <Icon size={14} strokeWidth={1.5} aria-hidden />
+            {label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
 
 export default function ProfilePage() {
-  return <ComingSoonPlaceholder title="Profile" ticketNumber="#148" />
+  return (
+    <main className="min-h-screen bg-page-bg px-4xl py-3xl">
+      <h1
+        className="text-text-primary font-semibold mb-2xl"
+        style={{ fontSize: 24, letterSpacing: '-0.5px', lineHeight: 1.35 }}
+      >
+        Profile
+      </h1>
+
+      <section className="mb-2xl">
+        <h2
+          className="text-text-primary font-semibold mb-md"
+          style={{ fontSize: 15, letterSpacing: '-0.2px', lineHeight: 1.35 }}
+        >
+          Appearance
+        </h2>
+        <ThemePicker />
+        <p
+          className="text-text-secondary mt-md"
+          style={{ fontSize: 13, lineHeight: 1.5 }}
+        >
+          Choose how Kantelo looks. &ldquo;Match system&rdquo; follows your
+          operating system preference.
+        </p>
+      </section>
+
+      <p
+        className="text-text-tertiary"
+        style={{ fontSize: 11, lineHeight: 1.4 }}
+      >
+        More settings coming soon &mdash; tracked in #148.
+      </p>
+    </main>
+  )
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from 'next'
 import { ClerkProvider } from '@clerk/nextjs'
+import { ThemeProvider } from '@/components/ThemeProvider'
 import { ibmPlexSans, finlandica } from './fonts'
 import './globals.css'
 
@@ -14,6 +15,23 @@ export const viewport: Viewport = {
   themeColor: '#0D6B52',
 }
 
+// Inline script that runs before hydration to set the correct data-theme
+// attribute on <html>. Prevents a light-mode flash for users whose stored
+// or system preference is dark. Kept as a string literal so it can be
+// rendered via dangerouslySetInnerHTML.
+const themeInitScript = `
+(function(){try{
+  var stored = localStorage.getItem('kantelo-theme');
+  var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  var resolved = stored === 'dark' || stored === 'light'
+    ? stored
+    : (prefersDark ? 'dark' : 'light');
+  if (resolved === 'dark') {
+    document.documentElement.setAttribute('data-theme', 'dark');
+  }
+}catch(e){}})();
+`
+
 export default function RootLayout({
   children,
 }: {
@@ -22,7 +40,12 @@ export default function RootLayout({
   return (
     <ClerkProvider>
       <html lang="en" className={`${ibmPlexSans.variable} ${finlandica.variable}`}>
-        <body>{children}</body>
+        <head>
+          <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+        </head>
+        <body>
+          <ThemeProvider>{children}</ThemeProvider>
+        </body>
       </html>
     </ClerkProvider>
   )

--- a/frontend/src/components/ThemeProvider.tsx
+++ b/frontend/src/components/ThemeProvider.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import {
+  createContext,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react'
+
+export type ThemePreference = 'system' | 'light' | 'dark'
+export type ResolvedTheme = 'light' | 'dark'
+
+interface ThemeContextValue {
+  /** The user's preference: 'system', 'light', or 'dark'. */
+  theme: ThemePreference
+  /** The actually rendered theme — resolves 'system' to light or dark. */
+  resolvedTheme: ResolvedTheme
+  /** Set the user's preference. Writes localStorage when explicit. */
+  setTheme: (next: ThemePreference) => void
+}
+
+export const ThemeContext = createContext<ThemeContextValue | null>(null)
+
+const STORAGE_KEY = 'kantelo-theme'
+
+function readStoredPreference(): ThemePreference {
+  if (typeof window === 'undefined') return 'system'
+  const raw = window.localStorage.getItem(STORAGE_KEY)
+  if (raw === 'light' || raw === 'dark') return raw
+  return 'system'
+}
+
+function detectSystem(): ResolvedTheme {
+  if (typeof window === 'undefined') return 'light'
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light'
+}
+
+function resolveTheme(
+  preference: ThemePreference,
+  system: ResolvedTheme,
+): ResolvedTheme {
+  return preference === 'system' ? system : preference
+}
+
+function applyDataTheme(resolved: ResolvedTheme) {
+  if (typeof document === 'undefined') return
+  if (resolved === 'dark') {
+    document.documentElement.setAttribute('data-theme', 'dark')
+  } else {
+    document.documentElement.removeAttribute('data-theme')
+  }
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  // Use lazy initializers so we read localStorage / matchMedia exactly once
+  // and only on the client. The first-paint script in layout.tsx has already
+  // set the correct data-theme attribute by this point.
+  const [theme, setThemeState] = useState<ThemePreference>(() =>
+    readStoredPreference(),
+  )
+  const [systemTheme, setSystemTheme] = useState<ResolvedTheme>(() =>
+    detectSystem(),
+  )
+
+  // Listen for OS-level color-scheme changes so "Match system" stays in sync.
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-color-scheme: dark)')
+    const handler = (e: MediaQueryListEvent) => {
+      setSystemTheme(e.matches ? 'dark' : 'light')
+    }
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [])
+
+  const resolvedTheme = resolveTheme(theme, systemTheme)
+
+  // Apply data-theme whenever the resolved theme changes.
+  useEffect(() => {
+    applyDataTheme(resolvedTheme)
+  }, [resolvedTheme])
+
+  const setTheme = useCallback((next: ThemePreference) => {
+    setThemeState(next)
+    if (next === 'system') {
+      window.localStorage.removeItem(STORAGE_KEY)
+    } else {
+      window.localStorage.setItem(STORAGE_KEY, next)
+    }
+  }, [])
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({ theme, resolvedTheme, setTheme }),
+    [theme, resolvedTheme, setTheme],
+  )
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+}

--- a/frontend/src/components/ThemeProvider.tsx
+++ b/frontend/src/components/ThemeProvider.tsx
@@ -56,15 +56,21 @@ function applyDataTheme(resolved: ResolvedTheme) {
 }
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  // Use lazy initializers so we read localStorage / matchMedia exactly once
-  // and only on the client. The first-paint script in layout.tsx has already
-  // set the correct data-theme attribute by this point.
-  const [theme, setThemeState] = useState<ThemePreference>(() =>
-    readStoredPreference(),
-  )
-  const [systemTheme, setSystemTheme] = useState<ResolvedTheme>(() =>
-    detectSystem(),
-  )
+  // Initial state must match between SSR and the first client render or
+  // React will warn about a hydration mismatch. localStorage and
+  // matchMedia aren't available on the server, so we render the
+  // defaults first, then reconcile from storage in a mount effect.
+  // The first-paint <head> script in layout.tsx has already set the
+  // correct data-theme attribute by this point, so page colors don't
+  // flicker — only the picker's selected pill resolves on mount.
+  const [theme, setThemeState] = useState<ThemePreference>('system')
+  const [systemTheme, setSystemTheme] = useState<ResolvedTheme>('light')
+
+  // Reconcile preference + system theme from the browser on mount.
+  useEffect(() => {
+    setThemeState(readStoredPreference())
+    setSystemTheme(detectSystem())
+  }, [])
 
   // Listen for OS-level color-scheme changes so "Match system" stays in sync.
   useEffect(() => {

--- a/frontend/src/hooks/useTheme.ts
+++ b/frontend/src/hooks/useTheme.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react'
+import { ThemeContext } from '@/components/ThemeProvider'
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext)
+  if (!ctx) {
+    throw new Error('useTheme must be used within a <ThemeProvider>')
+  }
+  return ctx
+}


### PR DESCRIPTION
Closes #187.

## Summary

Phase 0 — PR 2: Theme provider + dark mode wiring. Lands the three-option theme model (Match system / Light / Dark) with first-paint resolution from localStorage, and replaces the Profile placeholder with a minimal preferences scaffold that hosts the picker.

## Changes

- **`src/components/ThemeProvider.tsx`** — React context with `theme` (`'system' | 'light' | 'dark'`) and `resolvedTheme` (`'light' | 'dark'`). Default is `'system'`. localStorage key `kantelo-theme` stores explicit choices; "Match system" clears the key. Listens for `(prefers-color-scheme: dark)` changes so Match-system mode follows the OS live.
- **`src/hooks/useTheme.ts`** — `useTheme()` hook, throws if used outside the provider.
- **`src/app/layout.tsx`** — inline `<head>` script runs before hydration to set `data-theme="dark"` on `<html>` if needed, preventing a light-mode flash. ThemeProvider wraps children.
- **`src/app/(app)/profile/page.tsx`** — replaces `ComingSoonPlaceholder` with a real preferences page: "Appearance" section + three-pill segmented picker (Monitor / Sun / Moon Lucide icons), description copy, and a "More coming soon — tracked in #148" hint.

## How it works

1. Server renders HTML with no `data-theme` attribute (light is the CSS default).
2. Browser parses `<head>` and runs the init script before rendering `<body>`. Script reads `localStorage['kantelo-theme']`, falls back to `prefers-color-scheme`. If resolved dark, sets `data-theme="dark"` on `<html>`.
3. Body renders with the correct theme via CSS variables defined in `tokens.css` — no flash.
4. React hydrates. ThemeProvider re-reads localStorage, registers the system-preference listener, and re-applies `data-theme` on changes.

## Out of scope (per audit sequencing)

- Backend `GET/PATCH /api/settings` sync — tracked in #176; Phase 4.
- Full Profile tab (#148) — instruments, suggestions preference, week-start, account section.
- UI primitive components (`Button`, `Pill`) — PR 3. The picker uses inline token utility classes for now.
- Retoning Today, Active session, etc. — PR 9+.

## Test plan

- [x] `npm run build` green
- [x] `npm run lint` green
- [x] `npm test` green
- [ ] Visit `/profile`, click each option → page bg + text colors flip between light and dark
- [ ] Reload after picking Light or Dark → preference persists
- [ ] Pick "Match system", flip OS theme → page follows without a reload
- [ ] Hard reload in Dark mode → no light-mode flash on first paint

🤖 Generated with [Claude Code](https://claude.com/claude-code)
