### PR TITLE
Fix /preview light scope inheriting dark from html theme

### DIFF
--- a/frontend/src/app/preview/PreviewContent.tsx
+++ b/frontend/src/app/preview/PreviewContent.tsx
@@ -170,7 +170,7 @@ function ThemeScope({
 }) {
   return (
     <div
-      data-theme={mode === 'dark' ? 'dark' : undefined}
+      data-theme={mode}
       className="bg-page-bg text-text-primary px-4xl py-3xl"
     >
       <p

--- a/frontend/src/lib/tokens.css
+++ b/frontend/src/lib/tokens.css
@@ -3,12 +3,15 @@
  *
  * Source of truth: docs/kantelo-design-tokens.md
  *
- * Light mode is the default (`:root`); dark mode activates when the
- * root element has `data-theme="dark"`. The theme provider that sets
- * that attribute lands in PR 2.
+ * Light mode is the default (`:root`); dark mode activates when an
+ * ancestor has `data-theme="dark"`. `data-theme="light"` is also
+ * supported so a subtree can be forced back to light even when the
+ * page-level theme is dark (used by the /preview route to show both
+ * modes side by side).
  */
 
-:root {
+:root,
+[data-theme="light"] {
   /* Surfaces */
   --page-bg: #F7F6F3;
   --card-bg: #FFFFFF;


### PR DESCRIPTION
Small follow-up to #191. On `/preview`, the left "light" column and right "dark" column were rendering identically when the page-level theme is dark — both inherited dark from `<html data-theme="dark">`.

## Cause

`tokens.css` only defined `:root` (light defaults) and `[data-theme="dark"]` (dark overrides). A subtree with no `data-theme` attribute had no rule asserting light, so it inherited whatever the ancestor had.

## Fix

- `tokens.css` — extend the light selector to `:root, [data-theme="light"]` so a subtree can be forced back to light even when an ancestor is dark.
- `PreviewContent.tsx` — `ThemeScope` now always sets `data-theme={mode}` (was previously omitting the attribute for light), so both columns assert their own mode.

One-line CSS change + a 1-character JSX change. Zero behavior change for anything outside `/preview`.

## Test plan

- [x] `npm run build` green
- [x] `npm run lint` green
- [x] `npm test` green (34 assertions)
- [ ] `cd frontend && npm run dev`, visit `/preview` while page theme is dark → left column shows warm-stone bg, right shows warm-dark bg
- [ ] Same with page theme set to light → light column unchanged, dark column dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)
