### PR TITLE
Frontend: Phase 0 PR 3b — UI primitives (display)

### DIFF
--- a/frontend/src/app/preview/PreviewContent.tsx
+++ b/frontend/src/app/preview/PreviewContent.tsx
@@ -1,12 +1,18 @@
 'use client'
 
 import { useState, type ReactNode } from 'react'
+import { Lightbulb } from 'lucide-react'
 import {
   Button,
   Pill,
   Checkbox,
   TextInput,
   TextArea,
+  Card,
+  SectionPip,
+  ProgressBar,
+  RotationBar,
+  StatCard,
 } from '@/components/ui'
 import {
   SECTION_COLORS_BY_NAME,
@@ -156,6 +162,115 @@ function Showcase() {
           onChange={(e) => setArea(e.target.value)}
         />
         <TextArea variant="recessed" rows={3} placeholder="Recessed textarea…" />
+      </Section>
+
+      <Section title="Card — variants">
+        <Card>
+          <div
+            className="text-text-primary font-semibold"
+            style={{ fontSize: 15, letterSpacing: '-0.2px' }}
+          >
+            Default card
+          </div>
+          <p
+            className="text-text-secondary mt-xs"
+            style={{ fontSize: 13, lineHeight: 1.5 }}
+          >
+            Plan card, section card, session history card. 18px padding,
+            10px radius, 1px border.
+          </p>
+        </Card>
+
+        <Card variant="suggestion" icon={<Lightbulb size={12} strokeWidth={2.5} />}>
+          <div
+            className="font-semibold"
+            style={{ fontSize: 13, color: 'var(--amber-text)' }}
+          >
+            Suggestion card
+          </div>
+          <p
+            className="mt-xs"
+            style={{ fontSize: 12, lineHeight: 1.5, color: 'var(--amber-text-muted)' }}
+          >
+            Pre-session coaching nudge. Amber chip on the left,
+            short rationale on the right.
+          </p>
+        </Card>
+
+        <Card variant="coaching">
+          A short post-session reflection from the coaching engine. No border,
+          coaching-bg, 13px text on coaching-text.
+        </Card>
+
+        <Card variant="hint">
+          In-session hint card. 11px text on text-secondary, left rail
+          accent, recessed background.
+        </Card>
+      </Section>
+
+      <Section title="SectionPip — all colors">
+        <Row>
+          {sectionColorNames.map((name) => (
+            <div key={name} className="flex items-center gap-xs">
+              <SectionPip color={SECTION_COLORS_BY_NAME[name]} />
+              <span
+                className="text-text-secondary"
+                style={{ fontSize: 11 }}
+              >
+                {name}
+              </span>
+            </div>
+          ))}
+        </Row>
+      </Section>
+
+      <Section title="ProgressBar — values">
+        <div className="space-y-md">
+          <ProgressBar value={0} label="Empty" />
+          <ProgressBar value={0.25} label="25%" />
+          <ProgressBar value={0.6} label="60%" />
+          <ProgressBar value={1} label="Full" />
+        </div>
+      </Section>
+
+      <Section title="RotationBar — configurations">
+        <div className="space-y-md">
+          <div>
+            <p
+              className="text-text-tertiary mb-xs"
+              style={{ fontSize: 11 }}
+            >
+              3-session rotation, on session 2
+            </p>
+            <RotationBar total={3} current={2} label="2 of 3" />
+          </div>
+          <div>
+            <p
+              className="text-text-tertiary mb-xs"
+              style={{ fontSize: 11 }}
+            >
+              5-session rotation, just started
+            </p>
+            <RotationBar total={5} current={1} label="1 of 5" />
+          </div>
+          <div>
+            <p
+              className="text-text-tertiary mb-xs"
+              style={{ fontSize: 11 }}
+            >
+              7-session rotation, complete
+            </p>
+            <RotationBar total={7} current={7} label="7 of 7" />
+          </div>
+        </div>
+      </Section>
+
+      <Section title="StatCard — session summary row">
+        <div className="grid grid-cols-3 gap-md">
+          <StatCard value="42" label="Minutes practiced" />
+          <StatCard value="6" label="Exercises completed" />
+          <StatCard value="3" label="Day streak" />
+        </div>
       </Section>
     </div>
   )

--- a/frontend/src/components/ui/Card.test.tsx
+++ b/frontend/src/components/ui/Card.test.tsx
@@ -16,7 +16,7 @@ describe('Card', () => {
 
   it('applies suggestion variant classes when requested', () => {
     render(
-      <Card variant="suggestion" data-testid="card">
+      <Card variant="suggestion" icon={<span>!</span>} data-testid="card">
         x
       </Card>,
     )
@@ -41,14 +41,19 @@ describe('Card', () => {
     expect(screen.getByTestId('card')).toHaveClass('bg-input-bg-recessed')
   })
 
-  it('renders the icon slot for suggestion variant', () => {
+  it('renders the icon slot for suggestion variant inside an aria-hidden chip', () => {
     render(
       <Card variant="suggestion" icon={<span data-testid="icon">!</span>}>
         body
       </Card>,
     )
-    expect(screen.getByTestId('icon')).toBeInTheDocument()
+    const icon = screen.getByTestId('icon')
+    expect(icon).toBeInTheDocument()
     expect(screen.getByText('body')).toBeInTheDocument()
+    // Chip wraps the icon and is decorative — assistive tech should skip it.
+    const chip = icon.parentElement
+    expect(chip).toHaveAttribute('aria-hidden', 'true')
+    expect(chip).toHaveClass('bg-amber-icon-bg')
   })
 
   it('forwards ref to underlying div', () => {

--- a/frontend/src/components/ui/Card.test.tsx
+++ b/frontend/src/components/ui/Card.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@/test/utils'
+import { Card } from './Card'
+
+describe('Card', () => {
+  it('renders children inside a div by default', () => {
+    render(<Card>hello</Card>)
+    const node = screen.getByText('hello')
+    expect(node.tagName).toBe('DIV')
+  })
+
+  it('applies default variant classes by default', () => {
+    render(<Card data-testid="card">x</Card>)
+    expect(screen.getByTestId('card')).toHaveClass('bg-card-bg')
+  })
+
+  it('applies suggestion variant classes when requested', () => {
+    render(
+      <Card variant="suggestion" data-testid="card">
+        x
+      </Card>,
+    )
+    expect(screen.getByTestId('card')).toHaveClass('bg-amber-bg')
+  })
+
+  it('applies coaching variant classes when requested', () => {
+    render(
+      <Card variant="coaching" data-testid="card">
+        x
+      </Card>,
+    )
+    expect(screen.getByTestId('card')).toHaveClass('bg-coaching-bg')
+  })
+
+  it('applies hint variant classes when requested', () => {
+    render(
+      <Card variant="hint" data-testid="card">
+        x
+      </Card>,
+    )
+    expect(screen.getByTestId('card')).toHaveClass('bg-input-bg-recessed')
+  })
+
+  it('renders the icon slot for suggestion variant', () => {
+    render(
+      <Card variant="suggestion" icon={<span data-testid="icon">!</span>}>
+        body
+      </Card>,
+    )
+    expect(screen.getByTestId('icon')).toBeInTheDocument()
+    expect(screen.getByText('body')).toBeInTheDocument()
+  })
+
+  it('forwards ref to underlying div', () => {
+    let captured: HTMLDivElement | null = null
+    render(
+      <Card
+        ref={(el) => {
+          captured = el
+        }}
+      >
+        x
+      </Card>,
+    )
+    expect(captured).toBeInstanceOf(HTMLDivElement)
+  })
+})

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -6,7 +6,7 @@ import {
 } from 'react'
 import { cx } from '@/lib/cx'
 
-export type CardVariant = 'default' | 'suggestion' | 'coaching' | 'hint'
+type CardVariant = 'default' | 'suggestion' | 'coaching' | 'hint'
 
 type CardCommonProps = HTMLAttributes<HTMLDivElement>
 

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -1,0 +1,67 @@
+import {
+  forwardRef,
+  type CSSProperties,
+  type HTMLAttributes,
+  type ReactNode,
+} from 'react'
+import { cx } from '@/lib/cx'
+
+export type CardVariant = 'default' | 'suggestion' | 'coaching' | 'hint'
+
+export interface CardProps extends HTMLAttributes<HTMLDivElement> {
+  variant?: CardVariant
+  // Suggestion variant only: content for the 18×18 amber chip on the left.
+  icon?: ReactNode
+}
+
+const VARIANT_CLASSES: Record<CardVariant, string> = {
+  default: 'bg-card-bg border border-border-default rounded-xl text-text-primary',
+  suggestion: 'bg-amber-bg border border-amber-border rounded-lg',
+  coaching: 'bg-coaching-bg rounded-lg text-coaching-text',
+  hint: 'bg-input-bg-recessed border-l-2 border-border-input rounded-md text-text-secondary',
+}
+
+const VARIANT_STYLES: Record<CardVariant, CSSProperties> = {
+  default: { padding: 18 },
+  suggestion: { padding: '12px 14px' },
+  coaching: { padding: 14, fontSize: 13, lineHeight: 1.55 },
+  hint: { padding: '8px 10px', fontSize: 11, lineHeight: 1.5 },
+}
+
+export const Card = forwardRef<HTMLDivElement, CardProps>(function Card(
+  { variant = 'default', icon, className, style, children, ...rest },
+  ref,
+) {
+  const classes = cx(VARIANT_CLASSES[variant], className)
+  const mergedStyle = { ...VARIANT_STYLES[variant], ...style }
+
+  if (variant === 'suggestion' && icon !== undefined) {
+    return (
+      <div
+        ref={ref}
+        className={cx(classes, 'flex items-start gap-md')}
+        style={mergedStyle}
+        {...rest}
+      >
+        <span
+          aria-hidden="true"
+          className="inline-flex flex-shrink-0 items-center justify-center rounded-sm text-white"
+          style={{
+            width: 18,
+            height: 18,
+            backgroundColor: 'var(--amber-icon-bg)',
+          }}
+        >
+          {icon}
+        </span>
+        <div className="min-w-0 flex-1">{children}</div>
+      </div>
+    )
+  }
+
+  return (
+    <div ref={ref} className={classes} style={mergedStyle} {...rest}>
+      {children}
+    </div>
+  )
+})

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -8,11 +8,19 @@ import { cx } from '@/lib/cx'
 
 export type CardVariant = 'default' | 'suggestion' | 'coaching' | 'hint'
 
-export interface CardProps extends HTMLAttributes<HTMLDivElement> {
-  variant?: CardVariant
-  // Suggestion variant only: content for the 18×18 amber chip on the left.
-  icon?: ReactNode
+type CardCommonProps = HTMLAttributes<HTMLDivElement>
+
+type StandardCardProps = CardCommonProps & {
+  variant?: 'default' | 'coaching' | 'hint'
 }
+
+type SuggestionCardProps = CardCommonProps & {
+  variant: 'suggestion'
+  // 18×18 amber chip content rendered to the left of children.
+  icon: ReactNode
+}
+
+export type CardProps = StandardCardProps | SuggestionCardProps
 
 const VARIANT_CLASSES: Record<CardVariant, string> = {
   default: 'bg-card-bg border border-border-default rounded-xl text-text-primary',
@@ -29,28 +37,25 @@ const VARIANT_STYLES: Record<CardVariant, CSSProperties> = {
 }
 
 export const Card = forwardRef<HTMLDivElement, CardProps>(function Card(
-  { variant = 'default', icon, className, style, children, ...rest },
+  props,
   ref,
 ) {
-  const classes = cx(VARIANT_CLASSES[variant], className)
-  const mergedStyle = { ...VARIANT_STYLES[variant], ...style }
-
-  if (variant === 'suggestion' && icon !== undefined) {
+  if (props.variant === 'suggestion') {
+    const { icon, className, style, children, ...rest } = props
     return (
       <div
         ref={ref}
-        className={cx(classes, 'flex items-start gap-md')}
-        style={mergedStyle}
+        className={cx(
+          VARIANT_CLASSES.suggestion,
+          'flex items-start gap-md',
+          className,
+        )}
+        style={{ ...VARIANT_STYLES.suggestion, ...style }}
         {...rest}
       >
         <span
           aria-hidden="true"
-          className="inline-flex flex-shrink-0 items-center justify-center rounded-sm text-white"
-          style={{
-            width: 18,
-            height: 18,
-            backgroundColor: 'var(--amber-icon-bg)',
-          }}
+          className="inline-flex h-[18px] w-[18px] flex-shrink-0 items-center justify-center rounded-sm bg-amber-icon-bg text-white"
         >
           {icon}
         </span>
@@ -59,8 +64,14 @@ export const Card = forwardRef<HTMLDivElement, CardProps>(function Card(
     )
   }
 
+  const { variant = 'default', className, style, children, ...rest } = props
   return (
-    <div ref={ref} className={classes} style={mergedStyle} {...rest}>
+    <div
+      ref={ref}
+      className={cx(VARIANT_CLASSES[variant], className)}
+      style={{ ...VARIANT_STYLES[variant], ...style }}
+      {...rest}
+    >
       {children}
     </div>
   )

--- a/frontend/src/components/ui/ProgressBar.test.tsx
+++ b/frontend/src/components/ui/ProgressBar.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@/test/utils'
+import { ProgressBar } from './ProgressBar'
+
+describe('ProgressBar', () => {
+  it('renders with role=progressbar', () => {
+    render(<ProgressBar value={0.5} />)
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  it('exposes the value as a rounded percentage via aria-valuenow', () => {
+    render(<ProgressBar value={0.42} />)
+    expect(screen.getByRole('progressbar')).toHaveAttribute(
+      'aria-valuenow',
+      '42',
+    )
+  })
+
+  it('clamps values below 0 to 0', () => {
+    render(<ProgressBar value={-1} />)
+    expect(screen.getByRole('progressbar')).toHaveAttribute(
+      'aria-valuenow',
+      '0',
+    )
+  })
+
+  it('clamps values above 1 to 100', () => {
+    render(<ProgressBar value={5} />)
+    expect(screen.getByRole('progressbar')).toHaveAttribute(
+      'aria-valuenow',
+      '100',
+    )
+  })
+
+  it('applies the label as aria-label', () => {
+    render(<ProgressBar value={0.5} label="Session progress" />)
+    expect(
+      screen.getByRole('progressbar', { name: 'Session progress' }),
+    ).toBeInTheDocument()
+  })
+
+  it('forwards ref to underlying div', () => {
+    let captured: HTMLDivElement | null = null
+    render(
+      <ProgressBar
+        value={0.5}
+        ref={(el) => {
+          captured = el
+        }}
+      />,
+    )
+    expect(captured).toBeInstanceOf(HTMLDivElement)
+  })
+})

--- a/frontend/src/components/ui/ProgressBar.test.tsx
+++ b/frontend/src/components/ui/ProgressBar.test.tsx
@@ -4,12 +4,12 @@ import { ProgressBar } from './ProgressBar'
 
 describe('ProgressBar', () => {
   it('renders with role=progressbar', () => {
-    render(<ProgressBar value={0.5} />)
+    render(<ProgressBar value={0.5} label="x" />)
     expect(screen.getByRole('progressbar')).toBeInTheDocument()
   })
 
   it('exposes the value as a rounded percentage via aria-valuenow', () => {
-    render(<ProgressBar value={0.42} />)
+    render(<ProgressBar value={0.42} label="x" />)
     expect(screen.getByRole('progressbar')).toHaveAttribute(
       'aria-valuenow',
       '42',
@@ -17,7 +17,7 @@ describe('ProgressBar', () => {
   })
 
   it('clamps values below 0 to 0', () => {
-    render(<ProgressBar value={-1} />)
+    render(<ProgressBar value={-1} label="x" />)
     expect(screen.getByRole('progressbar')).toHaveAttribute(
       'aria-valuenow',
       '0',
@@ -25,10 +25,18 @@ describe('ProgressBar', () => {
   })
 
   it('clamps values above 1 to 100', () => {
-    render(<ProgressBar value={5} />)
+    render(<ProgressBar value={5} label="x" />)
     expect(screen.getByRole('progressbar')).toHaveAttribute(
       'aria-valuenow',
       '100',
+    )
+  })
+
+  it('treats NaN as 0', () => {
+    render(<ProgressBar value={Number.NaN} label="x" />)
+    expect(screen.getByRole('progressbar')).toHaveAttribute(
+      'aria-valuenow',
+      '0',
     )
   })
 
@@ -39,11 +47,21 @@ describe('ProgressBar', () => {
     ).toBeInTheDocument()
   })
 
+  it('renders an inner fill whose width matches the value', () => {
+    render(<ProgressBar value={0.6} label="x" />)
+    const fill = screen
+      .getByRole('progressbar')
+      .querySelector(':scope > div') as HTMLElement | null
+    expect(fill).not.toBeNull()
+    expect(fill).toHaveStyle({ width: '60%' })
+  })
+
   it('forwards ref to underlying div', () => {
     let captured: HTMLDivElement | null = null
     render(
       <ProgressBar
         value={0.5}
+        label="x"
         ref={(el) => {
           captured = el
         }}

--- a/frontend/src/components/ui/ProgressBar.tsx
+++ b/frontend/src/components/ui/ProgressBar.tsx
@@ -1,0 +1,37 @@
+import { forwardRef, type HTMLAttributes } from 'react'
+import { cx } from '@/lib/cx'
+
+export interface ProgressBarProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'role'> {
+  // 0..1 — values outside the range are clamped.
+  value: number
+  label?: string
+}
+
+export const ProgressBar = forwardRef<HTMLDivElement, ProgressBarProps>(
+  function ProgressBar(
+    { value, label, className, style, ...rest },
+    ref,
+  ) {
+    const clamped = Math.max(0, Math.min(1, value))
+    const pct = `${(clamped * 100).toFixed(2)}%`
+    return (
+      <div
+        ref={ref}
+        role="progressbar"
+        aria-label={label}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={Math.round(clamped * 100)}
+        className={cx('w-full overflow-hidden bg-border-default', className)}
+        style={{ height: 3, borderRadius: 2, ...style }}
+        {...rest}
+      >
+        <div
+          className="h-full bg-primary transition-[width]"
+          style={{ width: pct, borderRadius: 2 }}
+        />
+      </div>
+    )
+  },
+)

--- a/frontend/src/components/ui/ProgressBar.tsx
+++ b/frontend/src/components/ui/ProgressBar.tsx
@@ -25,7 +25,7 @@ export const ProgressBar = forwardRef<HTMLDivElement, ProgressBarProps>(
         aria-label={label}
         aria-valuemin={0}
         aria-valuemax={100}
-        aria-valuenow={Math.round(clamped * 100)}
+        aria-valuenow={pctNum}
         className={cx('w-full overflow-hidden bg-border-default', className)}
         style={{ height: 3, borderRadius: 2, ...style }}
         {...rest}

--- a/frontend/src/components/ui/ProgressBar.tsx
+++ b/frontend/src/components/ui/ProgressBar.tsx
@@ -3,9 +3,10 @@ import { cx } from '@/lib/cx'
 
 export interface ProgressBarProps
   extends Omit<HTMLAttributes<HTMLDivElement>, 'role'> {
-  // 0..1 — values outside the range are clamped.
+  // 0..1 — values outside the range are clamped; NaN is treated as 0.
   value: number
-  label?: string
+  // Required for accessibility (becomes aria-label on the progressbar).
+  label: string
 }
 
 export const ProgressBar = forwardRef<HTMLDivElement, ProgressBarProps>(
@@ -13,8 +14,10 @@ export const ProgressBar = forwardRef<HTMLDivElement, ProgressBarProps>(
     { value, label, className, style, ...rest },
     ref,
   ) {
-    const clamped = Math.max(0, Math.min(1, value))
-    const pct = `${(clamped * 100).toFixed(2)}%`
+    const safe = Number.isFinite(value) ? value : 0
+    const clamped = Math.max(0, Math.min(1, safe))
+    const pctNum = Math.round(clamped * 100)
+    const pct = `${pctNum}%`
     return (
       <div
         ref={ref}

--- a/frontend/src/components/ui/RotationBar.test.tsx
+++ b/frontend/src/components/ui/RotationBar.test.tsx
@@ -4,17 +4,21 @@ import { RotationBar } from './RotationBar'
 
 describe('RotationBar', () => {
   it('renders with role=progressbar', () => {
-    render(<RotationBar total={3} current={1} />)
+    render(<RotationBar total={3} current={1} label="x" />)
     expect(screen.getByRole('progressbar')).toBeInTheDocument()
   })
 
   it('renders the requested number of segments', () => {
-    const { container } = render(<RotationBar total={5} current={2} />)
+    const { container } = render(
+      <RotationBar total={5} current={2} label="x" />,
+    )
     expect(container.querySelectorAll('span').length).toBe(5)
   })
 
   it('fills the first `current` segments with the primary class', () => {
-    const { container } = render(<RotationBar total={4} current={2} />)
+    const { container } = render(
+      <RotationBar total={4} current={2} label="x" />,
+    )
     const segments = Array.from(container.querySelectorAll('span'))
     expect(segments[0]).toHaveClass('bg-primary')
     expect(segments[1]).toHaveClass('bg-primary')
@@ -23,14 +27,14 @@ describe('RotationBar', () => {
   })
 
   it('exposes total + current via aria-value attributes', () => {
-    render(<RotationBar total={7} current={3} />)
+    render(<RotationBar total={7} current={3} label="x" />)
     const bar = screen.getByRole('progressbar')
     expect(bar).toHaveAttribute('aria-valuemax', '7')
     expect(bar).toHaveAttribute('aria-valuenow', '3')
   })
 
   it('clamps current above total to total', () => {
-    render(<RotationBar total={3} current={10} />)
+    render(<RotationBar total={3} current={10} label="x" />)
     expect(screen.getByRole('progressbar')).toHaveAttribute(
       'aria-valuenow',
       '3',
@@ -38,9 +42,42 @@ describe('RotationBar', () => {
   })
 
   it('renders an empty bar when current is 0', () => {
-    const { container } = render(<RotationBar total={3} current={0} />)
+    const { container } = render(
+      <RotationBar total={3} current={0} label="x" />,
+    )
     const segments = Array.from(container.querySelectorAll('span'))
     segments.forEach((s) => expect(s).toHaveClass('bg-border-default'))
+  })
+
+  it('renders no segments when total is 0', () => {
+    const { container } = render(
+      <RotationBar total={0} current={0} label="x" />,
+    )
+    expect(container.querySelectorAll('span').length).toBe(0)
+    expect(screen.getByRole('progressbar')).toHaveAttribute(
+      'aria-valuemax',
+      '0',
+    )
+  })
+
+  it('treats NaN total/current as 0', () => {
+    render(
+      <RotationBar
+        total={Number.NaN}
+        current={Number.NaN}
+        label="x"
+      />,
+    )
+    const bar = screen.getByRole('progressbar')
+    expect(bar).toHaveAttribute('aria-valuemax', '0')
+    expect(bar).toHaveAttribute('aria-valuenow', '0')
+  })
+
+  it('applies the label as aria-label', () => {
+    render(<RotationBar total={3} current={2} label="Rotation progress" />)
+    expect(
+      screen.getByRole('progressbar', { name: 'Rotation progress' }),
+    ).toBeInTheDocument()
   })
 
   it('forwards ref to underlying div', () => {
@@ -49,6 +86,7 @@ describe('RotationBar', () => {
       <RotationBar
         total={3}
         current={1}
+        label="x"
         ref={(el) => {
           captured = el
         }}

--- a/frontend/src/components/ui/RotationBar.test.tsx
+++ b/frontend/src/components/ui/RotationBar.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@/test/utils'
+import { RotationBar } from './RotationBar'
+
+describe('RotationBar', () => {
+  it('renders with role=progressbar', () => {
+    render(<RotationBar total={3} current={1} />)
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  it('renders the requested number of segments', () => {
+    const { container } = render(<RotationBar total={5} current={2} />)
+    expect(container.querySelectorAll('span').length).toBe(5)
+  })
+
+  it('fills the first `current` segments with the primary class', () => {
+    const { container } = render(<RotationBar total={4} current={2} />)
+    const segments = Array.from(container.querySelectorAll('span'))
+    expect(segments[0]).toHaveClass('bg-primary')
+    expect(segments[1]).toHaveClass('bg-primary')
+    expect(segments[2]).toHaveClass('bg-border-default')
+    expect(segments[3]).toHaveClass('bg-border-default')
+  })
+
+  it('exposes total + current via aria-value attributes', () => {
+    render(<RotationBar total={7} current={3} />)
+    const bar = screen.getByRole('progressbar')
+    expect(bar).toHaveAttribute('aria-valuemax', '7')
+    expect(bar).toHaveAttribute('aria-valuenow', '3')
+  })
+
+  it('clamps current above total to total', () => {
+    render(<RotationBar total={3} current={10} />)
+    expect(screen.getByRole('progressbar')).toHaveAttribute(
+      'aria-valuenow',
+      '3',
+    )
+  })
+
+  it('renders an empty bar when current is 0', () => {
+    const { container } = render(<RotationBar total={3} current={0} />)
+    const segments = Array.from(container.querySelectorAll('span'))
+    segments.forEach((s) => expect(s).toHaveClass('bg-border-default'))
+  })
+
+  it('forwards ref to underlying div', () => {
+    let captured: HTMLDivElement | null = null
+    render(
+      <RotationBar
+        total={3}
+        current={1}
+        ref={(el) => {
+          captured = el
+        }}
+      />,
+    )
+    expect(captured).toBeInstanceOf(HTMLDivElement)
+  })
+})

--- a/frontend/src/components/ui/RotationBar.test.tsx
+++ b/frontend/src/components/ui/RotationBar.test.tsx
@@ -49,18 +49,16 @@ describe('RotationBar', () => {
     segments.forEach((s) => expect(s).toHaveClass('bg-border-default'))
   })
 
-  it('renders no segments when total is 0', () => {
+  it('renders no segments and drops the progressbar role when total is 0', () => {
     const { container } = render(
       <RotationBar total={0} current={0} label="x" />,
     )
     expect(container.querySelectorAll('span').length).toBe(0)
-    expect(screen.getByRole('progressbar')).toHaveAttribute(
-      'aria-valuemax',
-      '0',
-    )
+    // No segments → no progressbar role for assistive tech.
+    expect(screen.queryByRole('progressbar')).toBeNull()
   })
 
-  it('treats NaN total/current as 0', () => {
+  it('treats NaN total/current as 0 (no progressbar role)', () => {
     render(
       <RotationBar
         total={Number.NaN}
@@ -68,9 +66,7 @@ describe('RotationBar', () => {
         label="x"
       />,
     )
-    const bar = screen.getByRole('progressbar')
-    expect(bar).toHaveAttribute('aria-valuemax', '0')
-    expect(bar).toHaveAttribute('aria-valuenow', '0')
+    expect(screen.queryByRole('progressbar')).toBeNull()
   })
 
   it('applies the label as aria-label', () => {

--- a/frontend/src/components/ui/RotationBar.tsx
+++ b/frontend/src/components/ui/RotationBar.tsx
@@ -3,11 +3,13 @@ import { cx } from '@/lib/cx'
 
 export interface RotationBarProps
   extends Omit<HTMLAttributes<HTMLDivElement>, 'role'> {
+  // Non-finite values are treated as 0 (rendering an empty bar).
   total: number
   // 1-indexed: segments [1..current] are filled, current+1..total are empty.
-  // Pass 0 to render an entirely-empty bar.
+  // Pass 0 to render an entirely-empty bar. Non-finite values become 0.
   current: number
-  label?: string
+  // Required for accessibility (becomes aria-label on the progressbar).
+  label: string
 }
 
 export const RotationBar = forwardRef<HTMLDivElement, RotationBarProps>(
@@ -15,8 +17,10 @@ export const RotationBar = forwardRef<HTMLDivElement, RotationBarProps>(
     { total, current, label, className, style, ...rest },
     ref,
   ) {
-    const segments = Math.max(0, Math.floor(total))
-    const filled = Math.max(0, Math.min(Math.floor(current), segments))
+    const safeTotal = Number.isFinite(total) ? total : 0
+    const safeCurrent = Number.isFinite(current) ? current : 0
+    const segments = Math.max(0, Math.floor(safeTotal))
+    const filled = Math.max(0, Math.min(Math.floor(safeCurrent), segments))
     return (
       <div
         ref={ref}

--- a/frontend/src/components/ui/RotationBar.tsx
+++ b/frontend/src/components/ui/RotationBar.tsx
@@ -1,0 +1,48 @@
+import { forwardRef, type HTMLAttributes } from 'react'
+import { cx } from '@/lib/cx'
+
+export interface RotationBarProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'role'> {
+  total: number
+  // 1-indexed: segments [1..current] are filled, current+1..total are empty.
+  // Pass 0 to render an entirely-empty bar.
+  current: number
+  label?: string
+}
+
+export const RotationBar = forwardRef<HTMLDivElement, RotationBarProps>(
+  function RotationBar(
+    { total, current, label, className, style, ...rest },
+    ref,
+  ) {
+    const segments = Math.max(0, Math.floor(total))
+    const filled = Math.max(0, Math.min(Math.floor(current), segments))
+    return (
+      <div
+        ref={ref}
+        role="progressbar"
+        aria-label={label}
+        aria-valuemin={0}
+        aria-valuemax={segments}
+        aria-valuenow={filled}
+        className={cx('flex w-full items-stretch', className)}
+        style={{ gap: 3, ...style }}
+        {...rest}
+      >
+        {Array.from({ length: segments }, (_, i) => {
+          const isFilled = i < filled
+          return (
+            <span
+              key={i}
+              className={cx(
+                'flex-1',
+                isFilled ? 'bg-primary' : 'bg-border-default',
+              )}
+              style={{ height: 3, borderRadius: 2 }}
+            />
+          )
+        })}
+      </div>
+    )
+  },
+)

--- a/frontend/src/components/ui/RotationBar.tsx
+++ b/frontend/src/components/ui/RotationBar.tsx
@@ -21,14 +21,22 @@ export const RotationBar = forwardRef<HTMLDivElement, RotationBarProps>(
     const safeCurrent = Number.isFinite(current) ? current : 0
     const segments = Math.max(0, Math.floor(safeTotal))
     const filled = Math.max(0, Math.min(Math.floor(safeCurrent), segments))
+    // With no segments there's no progress to report — render a plain div
+    // so assistive tech doesn't announce an empty progressbar.
+    const ariaProps =
+      segments > 0
+        ? {
+            role: 'progressbar' as const,
+            'aria-label': label,
+            'aria-valuemin': 0,
+            'aria-valuemax': segments,
+            'aria-valuenow': filled,
+          }
+        : {}
     return (
       <div
         ref={ref}
-        role="progressbar"
-        aria-label={label}
-        aria-valuemin={0}
-        aria-valuemax={segments}
-        aria-valuenow={filled}
+        {...ariaProps}
         className={cx('flex w-full items-stretch', className)}
         style={{ gap: 3, ...style }}
         {...rest}

--- a/frontend/src/components/ui/SectionPip.test.tsx
+++ b/frontend/src/components/ui/SectionPip.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@/test/utils'
+import { SectionPip } from './SectionPip'
+import { SECTION_COLORS_BY_NAME } from '@/lib/section-colors'
+
+describe('SectionPip', () => {
+  it('renders as a span', () => {
+    render(
+      <SectionPip
+        color={SECTION_COLORS_BY_NAME.warmup}
+        data-testid="pip"
+      />,
+    )
+    expect(screen.getByTestId('pip').tagName).toBe('SPAN')
+  })
+
+  it('applies the section color via inline backgroundColor', () => {
+    render(
+      <SectionPip
+        color={SECTION_COLORS_BY_NAME.blue}
+        data-testid="pip"
+      />,
+    )
+    expect(screen.getByTestId('pip')).toHaveStyle({
+      backgroundColor: SECTION_COLORS_BY_NAME.blue.pip,
+    })
+  })
+
+  it('defaults to an 8×8 pip', () => {
+    render(
+      <SectionPip
+        color={SECTION_COLORS_BY_NAME.cooldown}
+        data-testid="pip"
+      />,
+    )
+    expect(screen.getByTestId('pip')).toHaveStyle({
+      width: '8px',
+      height: '8px',
+    })
+  })
+
+  it('respects a custom size', () => {
+    render(
+      <SectionPip
+        color={SECTION_COLORS_BY_NAME.purple}
+        size={12}
+        data-testid="pip"
+      />,
+    )
+    expect(screen.getByTestId('pip')).toHaveStyle({
+      width: '12px',
+      height: '12px',
+    })
+  })
+
+  it('is aria-hidden by default (decorative)', () => {
+    render(
+      <SectionPip
+        color={SECTION_COLORS_BY_NAME.amber}
+        data-testid="pip"
+      />,
+    )
+    expect(screen.getByTestId('pip')).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('forwards ref to underlying span', () => {
+    let captured: HTMLSpanElement | null = null
+    render(
+      <SectionPip
+        color={SECTION_COLORS_BY_NAME.olive}
+        ref={(el) => {
+          captured = el
+        }}
+      />,
+    )
+    expect(captured).toBeInstanceOf(HTMLSpanElement)
+  })
+})

--- a/frontend/src/components/ui/SectionPip.tsx
+++ b/frontend/src/components/ui/SectionPip.tsx
@@ -1,0 +1,31 @@
+import { forwardRef, type HTMLAttributes } from 'react'
+import { cx } from '@/lib/cx'
+import type { SectionColor } from '@/lib/section-colors'
+
+export interface SectionPipProps
+  extends Omit<HTMLAttributes<HTMLSpanElement>, 'color'> {
+  color: SectionColor
+  size?: number
+}
+
+export const SectionPip = forwardRef<HTMLSpanElement, SectionPipProps>(
+  function SectionPip(
+    { color, size = 8, className, style, ...rest },
+    ref,
+  ) {
+    return (
+      <span
+        ref={ref}
+        aria-hidden="true"
+        className={cx('inline-block rounded-round', className)}
+        style={{
+          width: size,
+          height: size,
+          backgroundColor: color.pip,
+          ...style,
+        }}
+        {...rest}
+      />
+    )
+  },
+)

--- a/frontend/src/components/ui/StatCard.test.tsx
+++ b/frontend/src/components/ui/StatCard.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@/test/utils'
+import { StatCard } from './StatCard'
+
+describe('StatCard', () => {
+  it('renders the value', () => {
+    render(<StatCard value="42" label="Minutes practiced" />)
+    expect(screen.getByText('42')).toBeInTheDocument()
+  })
+
+  it('renders the label', () => {
+    render(<StatCard value="42" label="Minutes practiced" />)
+    expect(screen.getByText('Minutes practiced')).toBeInTheDocument()
+  })
+
+  it('accepts a ReactNode value (e.g., with units)', () => {
+    render(
+      <StatCard
+        value={
+          <>
+            42<span data-testid="unit">m</span>
+          </>
+        }
+        label="Practiced"
+      />,
+    )
+    expect(screen.getByTestId('unit')).toBeInTheDocument()
+  })
+
+  it('applies card-bg-inset background class', () => {
+    render(
+      <StatCard value="x" label="y" data-testid="stat" />,
+    )
+    expect(screen.getByTestId('stat')).toHaveClass('bg-card-bg-inset')
+  })
+
+  it('forwards ref to underlying div', () => {
+    let captured: HTMLDivElement | null = null
+    render(
+      <StatCard
+        value="x"
+        label="y"
+        ref={(el) => {
+          captured = el
+        }}
+      />,
+    )
+    expect(captured).toBeInstanceOf(HTMLDivElement)
+  })
+})

--- a/frontend/src/components/ui/StatCard.tsx
+++ b/frontend/src/components/ui/StatCard.tsx
@@ -1,0 +1,33 @@
+import { forwardRef, type HTMLAttributes, type ReactNode } from 'react'
+import { cx } from '@/lib/cx'
+
+export interface StatCardProps extends HTMLAttributes<HTMLDivElement> {
+  value: ReactNode
+  label: string
+}
+
+export const StatCard = forwardRef<HTMLDivElement, StatCardProps>(
+  function StatCard({ value, label, className, style, ...rest }, ref) {
+    return (
+      <div
+        ref={ref}
+        className={cx('rounded-lg bg-card-bg-inset', className)}
+        style={{ padding: 12, ...style }}
+        {...rest}
+      >
+        <div
+          className="text-text-primary"
+          style={{ fontSize: 22, fontWeight: 500, lineHeight: 1.2 }}
+        >
+          {value}
+        </div>
+        <div
+          className="text-text-secondary"
+          style={{ fontSize: 11, fontWeight: 400, lineHeight: 1.4, marginTop: 4 }}
+        >
+          {label}
+        </div>
+      </div>
+    )
+  },
+)

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -12,3 +12,18 @@ export type { TextInputProps, TextInputVariant } from './TextInput'
 
 export { TextArea } from './TextArea'
 export type { TextAreaProps, TextAreaVariant } from './TextArea'
+
+export { Card } from './Card'
+export type { CardProps, CardVariant } from './Card'
+
+export { SectionPip } from './SectionPip'
+export type { SectionPipProps } from './SectionPip'
+
+export { ProgressBar } from './ProgressBar'
+export type { ProgressBarProps } from './ProgressBar'
+
+export { RotationBar } from './RotationBar'
+export type { RotationBarProps } from './RotationBar'
+
+export { StatCard } from './StatCard'
+export type { StatCardProps } from './StatCard'

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -14,7 +14,7 @@ export { TextArea } from './TextArea'
 export type { TextAreaProps, TextAreaVariant } from './TextArea'
 
 export { Card } from './Card'
-export type { CardProps, CardVariant } from './Card'
+export type { CardProps } from './Card'
 
 export { SectionPip } from './SectionPip'
 export type { SectionPipProps } from './SectionPip'


### PR DESCRIPTION
## Summary

PR 3b in the Phase 0 sequence — display primitives. Adds five non-interactive primitives to `src/components/ui/` and extends `/preview` to showcase every variant in both light and dark scope. No screen retoning.

**Primitives added:**
- **Card** — `default | suggestion | coaching | hint`. Suggestion variant accepts an `icon` slot for the amber chip.
- **SectionPip** — 8×8 colored circle, takes a `SectionColor` from `@/lib/section-colors`.
- **ProgressBar** — 3px track, value 0–1, `role="progressbar"` + aria-value attrs, clamps out-of-range input.
- **RotationBar** — N segments with 3px gaps, current+past filled, future empty, `role="progressbar"`.
- **StatCard** — inset background, large value + small label for the session summary row.

`src/components/ui/index.ts` extended with the new exports.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 65 tests across 11 files pass (31 new across 5 files)
- [x] `npm run build` — succeeds
- [ ] Visit `/preview` locally and confirm every new primitive renders in both light and dark scope
- [ ] Confirm `SectionPip` circles render in all 10 section colors

## Notes

- `SectionPipProps` omits the deprecated `color` prop from `HTMLAttributes<HTMLSpanElement>` so the prop name can carry the `SectionColor` instead. Same trick may be needed for other future primitives that want to override standard HTML attribute names.
- Padding/typography for Card variants is applied via inline `style` rather than Tailwind utilities so consumers can override per-instance without class-merge ambiguity.

Closes #195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
