### PR TITLE
Suppress hydration warning on <html> for theme init script

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -39,7 +39,18 @@ export default function RootLayout({
 }) {
   return (
     <ClerkProvider>
-      <html lang="en" className={`${ibmPlexSans.variable} ${finlandica.variable}`}>
+      {/*
+        suppressHydrationWarning: the themeInitScript above mutates
+        <html>'s data-theme attribute before React hydrates, so the
+        server markup and the client's first render intentionally
+        differ on this element. Scoped one level deep — it does not
+        suppress warnings for descendants.
+      */}
+      <html
+        lang="en"
+        suppressHydrationWarning
+        className={`${ibmPlexSans.variable} ${finlandica.variable}`}
+      >
         <head>
           <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
         </head>


### PR DESCRIPTION
## Problem

On every dark-mode page load the console logs:

```
Warning: Extra attributes from the server: data-theme
    at html
    ...
```

## Cause

`src/app/layout.tsx` renders an inline `themeInitScript` in `<head>` that sets `data-theme="dark"` on `<html>` **before React hydrates**, to prevent a light-mode flash for users whose stored/system preference is dark (audit decision #2). `RootLayout` itself renders `<html>` without `data-theme`, so at hydration React finds an attribute on the real DOM node it didn't render and warns. It only fires in dark mode, since the script no-ops for light.

## Fix

Add `suppressHydrationWarning` to the `<html>` element — the standard Next.js / `next-themes` remedy for a theme script that intentionally mutates `<html>` pre-hydration. It's scoped one level deep (this element's own attributes only), not the subtree, so real mismatches elsewhere still surface. No behavior change; `ThemeProvider` logic is untouched.

## Verification

- `npm run lint` clean.
- Manually: warning no longer appears on dark-mode load of `/today`; theme still applies with no flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)