### PR TITLE
Extract shared Dialog/Sheet primitive (#173)

### DIFF
--- a/frontend/src/components/AddBlockSheet.tsx
+++ b/frontend/src/components/AddBlockSheet.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useApi } from '@/lib/useApi'
+import { Sheet } from './ui'
 import type {
   CuratedBlock,
   RecentBlock,
@@ -36,27 +37,6 @@ export default function AddBlockSheet({
   const [recent, setRecent] = useState<RecentBlock[]>([])
   const [loading, setLoading] = useState(false)
   const [submitting, setSubmitting] = useState(false)
-  const closeButtonRef = useRef<HTMLButtonElement>(null)
-  const onCloseRef = useRef(onClose)
-  useEffect(() => {
-    onCloseRef.current = onClose
-  }, [onClose])
-
-  // Lock body scroll while open and close on Escape. Mount-only effect so
-  // parent re-renders don't re-fire focus/scroll-lock setup.
-  useEffect(() => {
-    const previousOverflow = document.body.style.overflow
-    document.body.style.overflow = 'hidden'
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onCloseRef.current()
-    }
-    document.addEventListener('keydown', onKey)
-    closeButtonRef.current?.focus()
-    return () => {
-      document.body.style.overflow = previousOverflow
-      document.removeEventListener('keydown', onKey)
-    }
-  }, [])
 
   useEffect(() => {
     if (tab === 'curated') {
@@ -97,111 +77,101 @@ export default function AddBlockSheet({
   }
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-end justify-center bg-black/40"
-      role="presentation"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose()
-      }}
+    <Sheet
+      onClose={onClose}
+      aria-label={`Add block to ${sectionName}`}
+      className="w-full max-w-lg bg-white rounded-t-2xl shadow-xl flex flex-col max-h-[85vh]"
     >
-      <div
-        role="dialog"
-        aria-modal="true"
-        aria-label={`Add block to ${sectionName}`}
-        className="w-full max-w-lg bg-white rounded-t-2xl shadow-xl flex flex-col max-h-[85vh]"
-      >
-        {/* Header */}
-        <div className="flex items-center justify-between px-4 pt-4 pb-2 border-b border-gray-100">
-          <p className="text-sm text-gray-500">Add to: {sectionName}</p>
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 pt-4 pb-2 border-b border-gray-100">
+        <p className="text-sm text-gray-500">Add to: {sectionName}</p>
+        <button
+          onClick={onClose}
+          className="text-sm text-gray-500 hover:text-gray-800 px-2 py-1 touch-manipulation"
+        >
+          Cancel
+        </button>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-1 px-4 pt-3">
+        {(['curated', 'recent', 'repertoire'] as Tab[]).map((t) => (
           <button
-            ref={closeButtonRef}
-            onClick={onClose}
-            className="text-sm text-gray-500 hover:text-gray-800 px-2 py-1 touch-manipulation"
+            key={t}
+            onClick={() => setTab(t)}
+            className={`px-3 py-1.5 rounded-full text-sm border ${
+              tab === t
+                ? 'bg-gray-900 text-white border-gray-900'
+                : 'bg-white border-gray-200 text-gray-600'
+            }`}
           >
-            Cancel
+            {t === 'curated' ? 'Curated' : t === 'recent' ? 'Recent' : 'Your rep.'}
           </button>
-        </div>
+        ))}
+      </div>
 
-        {/* Tabs */}
-        <div className="flex gap-1 px-4 pt-3">
-          {(['curated', 'recent', 'repertoire'] as Tab[]).map((t) => (
-            <button
-              key={t}
-              onClick={() => setTab(t)}
-              className={`px-3 py-1.5 rounded-full text-sm border ${
-                tab === t
-                  ? 'bg-gray-900 text-white border-gray-900'
-                  : 'bg-white border-gray-200 text-gray-600'
-              }`}
-            >
-              {t === 'curated' ? 'Curated' : t === 'recent' ? 'Recent' : 'Your rep.'}
-            </button>
-          ))}
+      {/* Search (curated only) */}
+      {tab === 'curated' && (
+        <div className="px-4 pt-3">
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search blocks or type your own..."
+            className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-primary-300"
+          />
         </div>
+      )}
 
-        {/* Search (curated only) */}
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto px-4 py-3">
         {tab === 'curated' && (
-          <div className="px-4 pt-3">
-            <input
-              type="text"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="Search blocks or type your own..."
-              className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-primary-300"
-            />
-          </div>
+          <CuratedList
+            blocks={curated}
+            loading={loading}
+            onPick={(b) =>
+              submit({
+                name: b.name,
+                curated_block_id: b.id,
+                description: b.description ?? undefined,
+                estimated_duration_minutes: b.default_duration_minutes,
+              })
+            }
+          />
         )}
-
-        {/* Content */}
-        <div className="flex-1 overflow-y-auto px-4 py-3">
-          {tab === 'curated' && (
-            <CuratedList
-              blocks={curated}
-              loading={loading}
-              onPick={(b) =>
-                submit({
-                  name: b.name,
-                  curated_block_id: b.id,
-                  description: b.description ?? undefined,
-                  estimated_duration_minutes: b.default_duration_minutes,
-                })
-              }
-            />
-          )}
-          {tab === 'recent' && (
-            <RecentList
-              blocks={recent}
-              loading={loading}
-              onPick={(b) =>
-                submit({
-                  name: b.name,
-                  curated_block_id: b.curated_block_id ?? undefined,
-                })
-              }
-            />
-          )}
-          {tab === 'repertoire' && (
-            <div className="py-12 text-center text-sm text-gray-400">
-              <p>Repertoire blocks coming soon.</p>
-              <p className="text-xs mt-1">Tracked in #167.</p>
-            </div>
-          )}
-        </div>
-
-        {/* Custom add (curated tab) */}
-        {tab === 'curated' && query.trim().length > 0 && (
-          <div className="border-t border-gray-100 px-4 py-3">
-            <button
-              onClick={handleAddCustom}
-              disabled={submitting}
-              className="w-full px-3 py-2 bg-primary-600 text-white rounded-lg text-sm font-medium hover:bg-primary-700 disabled:opacity-50"
-            >
-              Add &quot;{query.trim()}&quot;
-            </button>
+        {tab === 'recent' && (
+          <RecentList
+            blocks={recent}
+            loading={loading}
+            onPick={(b) =>
+              submit({
+                name: b.name,
+                curated_block_id: b.curated_block_id ?? undefined,
+              })
+            }
+          />
+        )}
+        {tab === 'repertoire' && (
+          <div className="py-12 text-center text-sm text-gray-400">
+            <p>Repertoire blocks coming soon.</p>
+            <p className="text-xs mt-1">Tracked in #167.</p>
           </div>
         )}
       </div>
-    </div>
+
+      {/* Custom add (curated tab) */}
+      {tab === 'curated' && query.trim().length > 0 && (
+        <div className="border-t border-gray-100 px-4 py-3">
+          <button
+            onClick={handleAddCustom}
+            disabled={submitting}
+            className="w-full px-3 py-2 bg-primary-600 text-white rounded-lg text-sm font-medium hover:bg-primary-700 disabled:opacity-50"
+          >
+            Add &quot;{query.trim()}&quot;
+          </button>
+        </div>
+      )}
+    </Sheet>
   )
 }
 

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import type { ReactNode } from 'react'
+import { Dialog } from './ui'
 
 interface ConfirmDialogProps {
   title: string
@@ -25,22 +26,30 @@ export default function ConfirmDialog({
       : 'px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700'
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
-      <div className="bg-white rounded-xl shadow-2xl max-w-md w-full p-6">
-        <h2 className="text-xl font-bold text-gray-800 mb-4">{title}</h2>
-        <div className="text-gray-600 mb-6">{message}</div>
-        <div className="flex gap-3 justify-end">
-          <button
-            onClick={onCancel}
-            className="px-4 py-2 text-gray-600 hover:text-gray-800"
-          >
-            Cancel
-          </button>
-          <button onClick={onConfirm} className={confirmClass}>
-            {confirmLabel}
-          </button>
-        </div>
+    <Dialog
+      onClose={onCancel}
+      placement="center"
+      aria-labelledby="confirm-dialog-title"
+      className="bg-white rounded-xl shadow-2xl max-w-md w-full p-6"
+    >
+      <h2
+        id="confirm-dialog-title"
+        className="text-xl font-bold text-gray-800 mb-4"
+      >
+        {title}
+      </h2>
+      <div className="text-gray-600 mb-6">{message}</div>
+      <div className="flex gap-3 justify-end">
+        <button
+          onClick={onCancel}
+          className="px-4 py-2 text-gray-600 hover:text-gray-800"
+        >
+          Cancel
+        </button>
+        <button onClick={onConfirm} className={confirmClass}>
+          {confirmLabel}
+        </button>
       </div>
-    </div>
+    </Dialog>
   )
 }

--- a/frontend/src/components/ui/Dialog.test.tsx
+++ b/frontend/src/components/ui/Dialog.test.tsx
@@ -74,6 +74,34 @@ describe('Dialog', () => {
     expect(second).toHaveFocus()
   })
 
+  it('keeps focus on the only focusable element when trapped', async () => {
+    const user = userEvent.setup()
+    render(
+      <Dialog onClose={() => {}} aria-label="d">
+        <button>Only</button>
+      </Dialog>,
+    )
+    const only = screen.getByText('Only')
+    expect(only).toHaveFocus()
+    await user.tab()
+    expect(only).toHaveFocus()
+    await user.tab({ shift: true })
+    expect(only).toHaveFocus()
+  })
+
+  it('focuses the panel when there are no focusable children', async () => {
+    const user = userEvent.setup()
+    render(
+      <Dialog onClose={() => {}} aria-label="d">
+        <p>Nothing focusable here</p>
+      </Dialog>,
+    )
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toHaveFocus()
+    await user.tab() // stays trapped on the panel
+    expect(dialog).toHaveFocus()
+  })
+
   it('locks body scroll while open and restores it on close', () => {
     const { unmount } = render(
       <Dialog onClose={() => {}} aria-label="d">
@@ -107,6 +135,30 @@ describe('Dialog', () => {
     expect(screen.getByText('Inside')).toHaveFocus()
 
     await user.keyboard('{Escape}')
+    expect(trigger).toHaveFocus()
+  })
+
+  it('restores focus to the trigger when dismissed via the backdrop', async () => {
+    const user = userEvent.setup()
+    function Harness() {
+      const [open, setOpen] = useState(false)
+      return (
+        <>
+          <button onClick={() => setOpen(true)}>Trigger</button>
+          {open && (
+            <Dialog onClose={() => setOpen(false)} aria-label="d">
+              <button>Inside</button>
+            </Dialog>
+          )}
+        </>
+      )
+    }
+    render(<Harness />)
+    const trigger = screen.getByText('Trigger')
+
+    await user.click(trigger)
+    const backdrop = screen.getByRole('dialog').parentElement as HTMLElement
+    await user.click(backdrop)
     expect(trigger).toHaveFocus()
   })
 })

--- a/frontend/src/components/ui/Dialog.test.tsx
+++ b/frontend/src/components/ui/Dialog.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi } from 'vitest'
+import { useState } from 'react'
+import { render, screen, userEvent } from '@/test/utils'
+import { Dialog, Sheet } from './Dialog'
+
+describe('Dialog', () => {
+  it('renders children in a labelled modal dialog', () => {
+    render(
+      <Dialog onClose={() => {}} aria-label="Demo dialog">
+        <button>Inside</button>
+      </Dialog>,
+    )
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+    expect(dialog).toHaveAttribute('aria-label', 'Demo dialog')
+    expect(screen.getByText('Inside')).toBeInTheDocument()
+  })
+
+  it('moves initial focus to the first focusable element', () => {
+    render(
+      <Dialog onClose={() => {}} aria-label="d">
+        <button>First</button>
+        <button>Second</button>
+      </Dialog>,
+    )
+    expect(screen.getByText('First')).toHaveFocus()
+  })
+
+  it('calls onClose on Escape', async () => {
+    const onClose = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <Dialog onClose={onClose} aria-label="d">
+        <button>X</button>
+      </Dialog>,
+    )
+    await user.keyboard('{Escape}')
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('dismisses on backdrop click but not on panel click', async () => {
+    const onClose = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <Dialog onClose={onClose} aria-label="d">
+        <button>X</button>
+      </Dialog>,
+    )
+    await user.click(screen.getByText('X'))
+    expect(onClose).not.toHaveBeenCalled()
+
+    const backdrop = screen.getByRole('dialog').parentElement as HTMLElement
+    await user.click(backdrop)
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('traps Tab focus within the dialog', async () => {
+    const user = userEvent.setup()
+    render(
+      <Dialog onClose={() => {}} aria-label="d">
+        <button>First</button>
+        <button>Second</button>
+      </Dialog>,
+    )
+    const first = screen.getByText('First')
+    const second = screen.getByText('Second')
+
+    expect(first).toHaveFocus()
+    await user.tab()
+    expect(second).toHaveFocus()
+    await user.tab() // wraps forward to first
+    expect(first).toHaveFocus()
+    await user.tab({ shift: true }) // wraps backward to last
+    expect(second).toHaveFocus()
+  })
+
+  it('locks body scroll while open and restores it on close', () => {
+    const { unmount } = render(
+      <Dialog onClose={() => {}} aria-label="d">
+        <button>X</button>
+      </Dialog>,
+    )
+    expect(document.body.style.overflow).toBe('hidden')
+    unmount()
+    expect(document.body.style.overflow).toBe('')
+  })
+
+  it('restores focus to the trigger on close', async () => {
+    const user = userEvent.setup()
+    function Harness() {
+      const [open, setOpen] = useState(false)
+      return (
+        <>
+          <button onClick={() => setOpen(true)}>Trigger</button>
+          {open && (
+            <Dialog onClose={() => setOpen(false)} aria-label="d">
+              <button>Inside</button>
+            </Dialog>
+          )}
+        </>
+      )
+    }
+    render(<Harness />)
+    const trigger = screen.getByText('Trigger')
+
+    await user.click(trigger)
+    expect(screen.getByText('Inside')).toHaveFocus()
+
+    await user.keyboard('{Escape}')
+    expect(trigger).toHaveFocus()
+  })
+})
+
+describe('Sheet', () => {
+  it('renders a bottom-anchored dialog', () => {
+    render(
+      <Sheet onClose={() => {}} aria-label="Demo sheet">
+        <button>Inside</button>
+      </Sheet>,
+    )
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toHaveAttribute('aria-label', 'Demo sheet')
+    // Bottom placement anchors the panel to the end of the cross axis.
+    expect(dialog.parentElement).toHaveClass('items-end')
+  })
+})

--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -1,0 +1,155 @@
+'use client'
+
+import { useEffect, useRef, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+
+export type DialogPlacement = 'center' | 'bottom'
+
+export interface DialogProps {
+  /** Called when the user requests dismissal (Escape or backdrop click). */
+  onClose: () => void
+  /** Centered modal (`center`) or bottom sheet (`bottom`). Defaults to `center`. */
+  placement?: DialogPlacement
+  /** Accessible name when there is no visible title element to point at. */
+  'aria-label'?: string
+  /** ID of the visible element that titles the dialog (preferred when one exists). */
+  'aria-labelledby'?: string
+  /** Classes for the panel. Visual styling lives with the consumer, not the primitive. */
+  className?: string
+  /** Panel contents. */
+  children: ReactNode
+}
+
+// Elements that can receive focus inside the panel. Disabled and
+// explicitly-removed (`tabindex="-1"`) elements are excluded by the selector.
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'textarea:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',')
+
+function getFocusable(container: HTMLElement | null): HTMLElement[] {
+  if (!container) return []
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+  )
+}
+
+/**
+ * Headless modal primitive: owns the accessibility behaviors shared by every
+ * modal surface — `role="dialog"`/`aria-modal`, focus trap, Escape to close,
+ * body scroll lock, backdrop-click dismiss, and focus restore to the trigger.
+ *
+ * It renders through a portal and applies no surface styling of its own; the
+ * consumer passes the panel's look via `className`. Use {@link Sheet} for the
+ * bottom-sheet variant.
+ */
+export function Dialog({
+  onClose,
+  placement = 'center',
+  className,
+  children,
+  ...aria
+}: DialogProps) {
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  // Keep the latest onClose without re-running the mount-only behavior effect.
+  const onCloseRef = useRef(onClose)
+  useEffect(() => {
+    onCloseRef.current = onClose
+  }, [onClose])
+
+  // Mount-only: scroll lock, initial focus, focus trap + Escape, and teardown
+  // that restores both. Runs once so parent re-renders don't disturb focus.
+  useEffect(() => {
+    const panel = panelRef.current
+    const previouslyFocused = document.activeElement as HTMLElement | null
+
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+
+    // Move focus into the dialog: first focusable element, else the panel.
+    const focusables = getFocusable(panel)
+    ;(focusables[0] ?? panel)?.focus()
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        onCloseRef.current()
+        return
+      }
+      if (e.key !== 'Tab') return
+
+      const f = getFocusable(panel)
+      if (f.length === 0) {
+        // Nothing to land on — keep focus on the panel.
+        e.preventDefault()
+        panel?.focus()
+        return
+      }
+      const first = f[0]
+      const last = f[f.length - 1]
+      const active = document.activeElement
+      const outside = !panel?.contains(active)
+
+      if (e.shiftKey && (active === first || outside)) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && (active === last || outside)) {
+        e.preventDefault()
+        first.focus()
+      }
+      // Interior tabs fall through so native focus order handles them.
+    }
+
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('keydown', onKeyDown)
+      document.body.style.overflow = previousOverflow
+      previouslyFocused?.focus?.()
+    }
+  }, [])
+
+  // Dialogs are only rendered client-side (on interaction), but guard anyway.
+  if (typeof document === 'undefined') return null
+
+  const placementClasses =
+    placement === 'bottom'
+      ? 'items-end justify-center'
+      : 'items-center justify-center p-4'
+
+  return createPortal(
+    <div
+      className={`fixed inset-0 z-50 flex bg-black/50 ${placementClasses}`}
+      onClick={(e) => {
+        // Only a click on the backdrop itself dismisses; clicks inside the
+        // panel have a different target and fall through.
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={aria['aria-label']}
+        aria-labelledby={aria['aria-labelledby']}
+        tabIndex={-1}
+        className={`outline-none ${className ?? ''}`}
+      >
+        {children}
+      </div>
+    </div>,
+    document.body,
+  )
+}
+
+/**
+ * Bottom-sheet variant of {@link Dialog} — same behaviors, anchored to the
+ * bottom of the viewport. Equivalent to `<Dialog placement="bottom" />`.
+ */
+export function Sheet(props: Omit<DialogProps, 'placement'>) {
+  return <Dialog placement="bottom" {...props} />
+}

--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -46,6 +46,12 @@ function getFocusable(container: HTMLElement | null): HTMLElement[] {
  * It renders through a portal and applies no surface styling of its own; the
  * consumer passes the panel's look via `className`. Use {@link Sheet} for the
  * bottom-sheet variant.
+ *
+ * Assumes a single dialog is open at a time: the body scroll lock and the
+ * `document`-level Escape/focus-trap listener are global, so two simultaneous
+ * instances would fight over focus and double-restore scroll. No consumer
+ * stacks them today — revisit (scope per-instance, or add a count) before
+ * nesting one inside another.
  */
 export function Dialog({
   onClose,
@@ -77,7 +83,6 @@ export function Dialog({
 
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
-        e.stopPropagation()
         onCloseRef.current()
         return
       }

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -27,3 +27,6 @@ export type { RotationBarProps } from './RotationBar'
 
 export { StatCard } from './StatCard'
 export type { StatCardProps } from './StatCard'
+
+export { Dialog, Sheet } from './Dialog'
+export type { DialogProps, DialogPlacement } from './Dialog'


### PR DESCRIPTION
Closes #173. Phase 0 PR 4.

## What

Adds a headless modal primitive that owns the accessibility behaviors shared by every modal surface, and refactors the two existing surfaces onto it. **Behavior only — no visual retone** (that stays in Phase 0 PR 9+); the panels look identical apart from one backdrop-opacity unification noted below.

## The primitive — `components/ui/Dialog.tsx`

Exports `Dialog` (centered modal) and `Sheet` (bottom sheet), sharing one behavior core:

- `role="dialog"` + `aria-modal="true"`, labelled via `aria-label` / `aria-labelledby`
- **Focus trap** — Tab/Shift+Tab wrap within the panel; focus can't escape
- **Escape** to close
- **Body scroll lock** while open
- **Backdrop-click** dismiss (clicks inside the panel don't dismiss)
- **Focus restore** to the triggering element on close
- Renders through a **portal**; honors token rules (2px focus outline via consumer focus styles, no animation so nothing to gate on `prefers-reduced-motion`)

It applies **no surface styling** — consumers pass the panel's look via `className`, which is why this carries no retone.

## Consumers refactored

- **`ConfirmDialog`** → composes `Dialog`. It previously had *none* of these behaviors, so this is a straight a11y upgrade (Escape, backdrop dismiss, scroll lock, focus trap, focus restore). Escape/backdrop map to `onCancel`.
- **`AddBlockSheet`** → composes `Sheet`, deleting its inline scroll-lock/Escape/initial-focus effect (now owned by the primitive). Its backdrop opacity unifies `black/40` → `black/50` to match `Dialog` — the only intentional visual delta.

## Acceptance criteria (#173)

- [x] Single primitive owns dialog accessibility behaviors
- [x] `ConfirmDialog` and `AddBlockSheet` use it
- [x] Focus trap works correctly (no escapes via Tab) — covered by tests
- [x] Focus returns to the trigger on close — covered by tests

## Tests / verification

- New `Dialog.test.tsx` (8 tests): aria, initial focus, Escape, backdrop vs panel click, Tab trap wrap-around, scroll lock + restore, focus restore to trigger. `Sheet` placement.
- Existing `ConfirmDialog` tests pass unchanged.
- Full suite **78/78**, `npm run lint` clean, `tsc --noEmit` clean, dev server compiles.

## Notes / out of scope

- **No `/preview` entry.** A portaled dialog escapes the preview's side-by-side `data-theme` scopes, and the primitive has no token styling to eyeball yet — it belongs with the retone, when there's something visual to show.
- The repertoire spot-management drawer (#167) is intended to plug into this same primitive.
- Per the architecture discussion: primitives stay hand-rolled; the deliberate Radix checkpoint is the upcoming **overflow menu**, not this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)