### PR TITLE
Extract shared AutoSaveInput / useAutoSaveField primitive (#171)

### DIFF
--- a/frontend/src/app/(app)/plans/[id]/page.tsx
+++ b/frontend/src/app/(app)/plans/[id]/page.tsx
@@ -15,6 +15,7 @@ import SessionTabs from '@/components/SessionTabs'
 import SectionCard from '@/components/SectionCard'
 import AddBlockSheet from '@/components/AddBlockSheet'
 import ConfirmDialog from '@/components/ConfirmDialog'
+import { AutoSaveInput } from '@/components/ui'
 
 // TODO(#168): replace hardcoded section_type with a real picker (template
 // editor + freeform session). All new sections in this PR are 'other'.
@@ -471,17 +472,10 @@ function PlanNameField({
   initial: string
   onCommit: (value: string) => void | Promise<void>
 }) {
-  const [value, setValue] = useState(initial)
   return (
-    <input
-      type="text"
-      value={value}
-      onChange={(e) => setValue(e.target.value)}
-      onBlur={() => {
-        const trimmed = value.trim()
-        if (trimmed && trimmed !== initial) onCommit(trimmed)
-        else if (!trimmed) setValue(initial)
-      }}
+    <AutoSaveInput
+      value={initial}
+      onCommit={onCommit}
       placeholder="Plan name"
       className="w-full text-xl font-semibold text-gray-900 bg-transparent placeholder-gray-300 focus:outline-none"
     />
@@ -495,19 +489,17 @@ function SessionFocusField({
   initial: string
   onCommit: (value: string) => void | Promise<void>
 }) {
-  const [value, setValue] = useState(initial)
   return (
     <div className="mt-3">
       <label className="block text-xs text-gray-500 mb-1">
         Session focus (shown on Today tab)
       </label>
-      <input
-        type="text"
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-        onBlur={() => {
-          if (value !== initial) onCommit(value)
-        }}
+      {/* Focus is optional and clearable, so don't trim or roll back on empty. */}
+      <AutoSaveInput
+        value={initial}
+        onCommit={onCommit}
+        trim={false}
+        rollbackWhenEmpty={false}
         placeholder="e.g. Intonation and bow control"
         className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-primary-300"
       />
@@ -526,19 +518,12 @@ function SessionRenameRow({
   onRename: (name: string) => void | Promise<void>
   onDelete: () => void
 }) {
-  const [name, setName] = useState(session.name)
   return (
     <div className="mt-3 flex items-center gap-2">
       <label className="block text-xs text-gray-500 shrink-0">Name</label>
-      <input
-        type="text"
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-        onBlur={() => {
-          const trimmed = name.trim()
-          if (trimmed && trimmed !== session.name) onRename(trimmed)
-          else if (!trimmed) setName(session.name)
-        }}
+      <AutoSaveInput
+        value={session.name}
+        onCommit={onRename}
         className="flex-1 px-3 py-1.5 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-primary-300"
       />
       {canDelete && (

--- a/frontend/src/components/BlockRow.tsx
+++ b/frontend/src/components/BlockRow.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useState } from 'react'
 import type { Block } from '@/lib/types'
+import { AutoSaveInput } from './ui'
 import TimeStepper from './TimeStepper'
 
 /**
@@ -28,15 +28,7 @@ export default function BlockRow({
   onDurationChange: (minutes: number) => void
   onDelete: () => void
 }) {
-  const [name, setName] = useState(block.name ?? block.piece_name ?? '')
   const isRepertoire = block.piece_id != null
-
-  const handleBlur = () => {
-    const trimmed = name.trim()
-    const original = block.name ?? block.piece_name ?? ''
-    if (trimmed && trimmed !== original) onRename(trimmed)
-    else if (!trimmed) setName(original)
-  }
 
   return (
     <div className="flex items-center gap-2 px-3 py-2 border-b border-gray-100 last:border-b-0">
@@ -63,11 +55,9 @@ export default function BlockRow({
       </div>
 
       {/* Name */}
-      <input
-        type="text"
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-        onBlur={handleBlur}
+      <AutoSaveInput
+        value={block.name ?? block.piece_name ?? ''}
+        onCommit={onRename}
         disabled={isRepertoire}
         placeholder="Block name"
         className="flex-1 min-w-0 bg-transparent text-sm text-gray-800 placeholder-gray-400 focus:outline-none disabled:text-gray-500"

--- a/frontend/src/components/SectionCard.tsx
+++ b/frontend/src/components/SectionCard.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useState } from 'react'
 import type { Section } from '@/lib/types'
+import { AutoSaveInput, useAutoSaveField } from './ui'
 import BlockRow from './BlockRow'
 
 export default function SectionCard({
@@ -31,22 +31,12 @@ export default function SectionCard({
   onChangeBlockDuration: (blockId: number, minutes: number) => void
   onDeleteBlock: (blockId: number) => void
 }) {
-  const [name, setName] = useState(section.name)
-  const [duration, setDuration] = useState(
-    String(section.estimated_duration_minutes)
-  )
-
-  const handleNameBlur = () => {
-    const trimmed = name.trim()
-    if (trimmed && trimmed !== section.name) onRename(trimmed)
-    else if (!trimmed) setName(section.name)
-  }
-
-  const handleDurationBlur = () => {
-    const parsed = Math.max(0, parseInt(duration, 10) || 0)
-    if (parsed !== section.estimated_duration_minutes) onDurationChange(parsed)
-    setDuration(String(parsed))
-  }
+  const duration = useAutoSaveField<number>({
+    value: section.estimated_duration_minutes,
+    onCommit: onDurationChange,
+    parse: (s) => Math.max(0, parseInt(s, 10) || 0),
+    rollbackWhenEmpty: false,
+  })
 
   return (
     <section className="bg-white rounded-xl border border-gray-200 mb-3 overflow-hidden">
@@ -72,20 +62,19 @@ export default function SectionCard({
             ▼
           </button>
         </div>
-        <input
-          type="text"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          onBlur={handleNameBlur}
+        <AutoSaveInput
+          value={section.name}
+          onCommit={onRename}
           placeholder="Section name"
           className="flex-1 min-w-0 bg-transparent text-sm font-medium text-gray-800 placeholder-gray-400 focus:outline-none"
         />
         <input
           type="number"
           min={0}
-          value={duration}
-          onChange={(e) => setDuration(e.target.value)}
-          onBlur={handleDurationBlur}
+          value={duration.value}
+          onChange={duration.onChange}
+          onFocus={duration.onFocus}
+          onBlur={duration.onBlur}
           className="w-12 bg-transparent text-sm text-gray-500 text-right tabular-nums focus:outline-none"
           aria-label="Section duration in minutes"
         />

--- a/frontend/src/components/ui/AutoSaveInput.test.tsx
+++ b/frontend/src/components/ui/AutoSaveInput.test.tsx
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, userEvent } from '@/test/utils'
+import { AutoSaveInput, AutoSaveTextarea } from './AutoSaveInput'
+import { useAutoSaveField } from './useAutoSaveField'
+
+describe('AutoSaveInput', () => {
+  it('renders the initial value', () => {
+    render(<AutoSaveInput value="hello" onCommit={vi.fn()} aria-label="f" />)
+    expect(screen.getByLabelText('f')).toHaveValue('hello')
+  })
+
+  it('commits the trimmed value on blur when it changed', async () => {
+    const onCommit = vi.fn()
+    const user = userEvent.setup()
+    render(<AutoSaveInput value="old" onCommit={onCommit} aria-label="f" />)
+    const input = screen.getByLabelText('f')
+
+    await user.clear(input)
+    await user.type(input, '  new  ')
+    await user.tab() // blur
+
+    expect(onCommit).toHaveBeenCalledExactlyOnceWith('new')
+    expect(input).toHaveValue('new') // display normalized to the trimmed value
+  })
+
+  it('does not commit when the value is unchanged', async () => {
+    const onCommit = vi.fn()
+    const user = userEvent.setup()
+    render(<AutoSaveInput value="same" onCommit={onCommit} aria-label="f" />)
+    const input = screen.getByLabelText('f')
+
+    await user.click(input)
+    await user.tab()
+    expect(onCommit).not.toHaveBeenCalled()
+  })
+
+  it('rolls back to the original value when emptied (default)', async () => {
+    const onCommit = vi.fn()
+    const user = userEvent.setup()
+    render(<AutoSaveInput value="keep" onCommit={onCommit} aria-label="f" />)
+    const input = screen.getByLabelText('f')
+
+    await user.clear(input)
+    await user.tab()
+
+    expect(onCommit).not.toHaveBeenCalled()
+    expect(input).toHaveValue('keep')
+  })
+
+  it('commits an empty value when trim and rollback are disabled', async () => {
+    const onCommit = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <AutoSaveInput
+        value="focus"
+        onCommit={onCommit}
+        trim={false}
+        rollbackWhenEmpty={false}
+        aria-label="f"
+      />,
+    )
+    const input = screen.getByLabelText('f')
+
+    await user.clear(input)
+    await user.tab()
+    expect(onCommit).toHaveBeenCalledExactlyOnceWith('')
+  })
+
+  it('re-syncs to a new value prop when not editing', () => {
+    const { rerender } = render(
+      <AutoSaveInput value="a" onCommit={vi.fn()} aria-label="f" />,
+    )
+    const input = screen.getByLabelText('f')
+    expect(input).toHaveValue('a')
+
+    rerender(<AutoSaveInput value="b" onCommit={vi.fn()} aria-label="f" />)
+    expect(input).toHaveValue('b')
+  })
+
+  it('preserves the in-flight draft when the value prop changes mid-edit', async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(
+      <AutoSaveInput value="server" onCommit={vi.fn()} aria-label="f" />,
+    )
+    const input = screen.getByLabelText('f')
+
+    await user.clear(input)
+    await user.type(input, 'typing') // focused → editing
+
+    // A background refresh arrives while the user is mid-edit.
+    rerender(<AutoSaveInput value="updated" onCommit={vi.fn()} aria-label="f" />)
+
+    expect(input).toHaveValue('typing') // draft preserved, not clobbered
+  })
+})
+
+describe('AutoSaveTextarea', () => {
+  it('commits the trimmed value on blur', async () => {
+    const onCommit = vi.fn()
+    const user = userEvent.setup()
+    render(<AutoSaveTextarea value="" onCommit={onCommit} aria-label="note" />)
+    const area = screen.getByLabelText('note')
+
+    await user.type(area, ' a note ')
+    await user.tab()
+    expect(onCommit).toHaveBeenCalledExactlyOnceWith('a note')
+  })
+})
+
+describe('useAutoSaveField (numeric)', () => {
+  function NumberField({
+    value,
+    onCommit,
+  }: {
+    value: number
+    onCommit: (n: number) => void
+  }) {
+    const field = useAutoSaveField<number>({
+      value,
+      onCommit,
+      parse: (s) => Math.max(0, parseInt(s, 10) || 0),
+      rollbackWhenEmpty: false,
+    })
+    return (
+      <input
+        type="number"
+        aria-label="n"
+        value={field.value}
+        onChange={field.onChange}
+        onFocus={field.onFocus}
+        onBlur={field.onBlur}
+      />
+    )
+  }
+
+  it('parses, clamps, and normalizes the display on blur', async () => {
+    const onCommit = vi.fn()
+    const user = userEvent.setup()
+    render(<NumberField value={30} onCommit={onCommit} />)
+    const input = screen.getByLabelText('n')
+
+    await user.clear(input)
+    await user.type(input, '07')
+    await user.tab()
+
+    expect(onCommit).toHaveBeenCalledExactlyOnceWith(7)
+    expect(input).toHaveValue(7) // "07" normalized to "7"
+  })
+
+  it('commits 0 when emptied (no rollback)', async () => {
+    const onCommit = vi.fn()
+    const user = userEvent.setup()
+    render(<NumberField value={5} onCommit={onCommit} />)
+    const input = screen.getByLabelText('n')
+
+    await user.clear(input)
+    await user.tab()
+    expect(onCommit).toHaveBeenCalledExactlyOnceWith(0)
+  })
+})

--- a/frontend/src/components/ui/AutoSaveInput.test.tsx
+++ b/frontend/src/components/ui/AutoSaveInput.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
+import { useState } from 'react'
 import { render, screen, userEvent } from '@/test/utils'
 import { AutoSaveInput, AutoSaveTextarea } from './AutoSaveInput'
 import { useAutoSaveField } from './useAutoSaveField'
@@ -74,6 +75,23 @@ describe('AutoSaveInput', () => {
     expect(input).toHaveValue('a')
 
     rerender(<AutoSaveInput value="b" onCommit={vi.fn()} aria-label="f" />)
+    expect(input).toHaveValue('b')
+  })
+
+  it('re-syncs to the committed value after a blur commit (controlled parent)', async () => {
+    // A real controlled parent: onCommit lifts the new value back into the prop.
+    function Controlled() {
+      const [value, setValue] = useState('a')
+      return <AutoSaveInput value={value} onCommit={setValue} aria-label="f" />
+    }
+    const user = userEvent.setup()
+    render(<Controlled />)
+    const input = screen.getByLabelText('f')
+
+    await user.clear(input)
+    await user.type(input, 'b')
+    await user.tab() // commit → parent updates the prop → field re-syncs
+
     expect(input).toHaveValue('b')
   })
 

--- a/frontend/src/components/ui/AutoSaveInput.tsx
+++ b/frontend/src/components/ui/AutoSaveInput.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import {
+  forwardRef,
+  type InputHTMLAttributes,
+  type TextareaHTMLAttributes,
+} from 'react'
+import { useAutoSaveField } from './useAutoSaveField'
+
+interface AutoSaveOwnProps {
+  /** Source-of-truth value from props/server. */
+  value: string
+  /** Commit a changed value on blur. */
+  onCommit: (next: string) => void
+  /** Trim before comparing/committing. Default `true`. */
+  trim?: boolean
+  /** Roll back to `value` when emptied instead of committing `''`. Default `true`. */
+  rollbackWhenEmpty?: boolean
+}
+
+export type AutoSaveInputProps = AutoSaveOwnProps &
+  Omit<
+    InputHTMLAttributes<HTMLInputElement>,
+    'value' | 'onChange' | 'onBlur' | 'onFocus'
+  >
+
+export type AutoSaveTextareaProps = AutoSaveOwnProps &
+  Omit<
+    TextareaHTMLAttributes<HTMLTextAreaElement>,
+    'value' | 'onChange' | 'onBlur' | 'onFocus'
+  >
+
+/**
+ * Auto-saving text input. Holds the in-flight edit, commits on blur, and
+ * re-syncs to `value` when not focused (see {@link useAutoSaveField}). Style-
+ * agnostic — pass `className` for the look you want.
+ */
+export const AutoSaveInput = forwardRef<HTMLInputElement, AutoSaveInputProps>(
+  function AutoSaveInput(
+    { value, onCommit, trim, rollbackWhenEmpty, type = 'text', ...rest },
+    ref,
+  ) {
+    const field = useAutoSaveField<string>({
+      value,
+      onCommit,
+      trim,
+      rollbackWhenEmpty,
+    })
+    return <input ref={ref} type={type} {...rest} {...field} />
+  },
+)
+
+/** Textarea counterpart to {@link AutoSaveInput}. */
+export const AutoSaveTextarea = forwardRef<
+  HTMLTextAreaElement,
+  AutoSaveTextareaProps
+>(function AutoSaveTextarea(
+  { value, onCommit, trim, rollbackWhenEmpty, ...rest },
+  ref,
+) {
+  const field = useAutoSaveField<string>({
+    value,
+    onCommit,
+    trim,
+    rollbackWhenEmpty,
+  })
+  return <textarea ref={ref} {...rest} {...field} />
+})

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -30,3 +30,12 @@ export type { StatCardProps } from './StatCard'
 
 export { Dialog, Sheet } from './Dialog'
 export type { DialogProps, DialogPlacement } from './Dialog'
+
+export { AutoSaveInput, AutoSaveTextarea } from './AutoSaveInput'
+export type { AutoSaveInputProps, AutoSaveTextareaProps } from './AutoSaveInput'
+
+export { useAutoSaveField } from './useAutoSaveField'
+export type {
+  UseAutoSaveFieldOptions,
+  AutoSaveFieldBinding,
+} from './useAutoSaveField'

--- a/frontend/src/components/ui/useAutoSaveField.ts
+++ b/frontend/src/components/ui/useAutoSaveField.ts
@@ -55,6 +55,9 @@ export function useAutoSaveField<T>({
   // Re-sync to the source value when it changes and the user isn't editing.
   // While focused, the in-flight draft is preserved so a background refresh
   // (multi-device sync, optimistic revert) can't clobber what's being typed.
+  // Deps are [value] only: `format`/`parse` are assumed behaviorally stable —
+  // a changed formatter alone won't re-render the draft. All current consumers
+  // pass constant helpers; revisit if one needs a value-dependent format.
   useEffect(() => {
     if (!editingRef.current) setDraft(formatRef.current(value))
   }, [value])

--- a/frontend/src/components/ui/useAutoSaveField.ts
+++ b/frontend/src/components/ui/useAutoSaveField.ts
@@ -1,0 +1,81 @@
+'use client'
+
+import { useEffect, useRef, useState, type ChangeEvent } from 'react'
+
+export interface UseAutoSaveFieldOptions<T> {
+  /** Source-of-truth value from props/server. */
+  value: T
+  /** Commit a changed value. Called on blur, only when the parsed value differs. */
+  onCommit: (next: T) => void
+  /** Render the value as the input's string. Defaults to `String(value)` (`''` for nullish). */
+  format?: (value: T) => string
+  /** Parse the (optionally trimmed) input string back to `T`. Required for non-string `T`. */
+  parse?: (input: string) => T
+  /** Trim the input before parsing and comparing. Default `true`. */
+  trim?: boolean
+  /** When the (trimmed) input is empty, roll back to `value` instead of committing. Default `true`. */
+  rollbackWhenEmpty?: boolean
+}
+
+export interface AutoSaveFieldBinding {
+  value: string
+  onChange: (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void
+  onFocus: () => void
+  onBlur: () => void
+}
+
+function defaultFormat<T>(value: T): string {
+  return value == null ? '' : String(value)
+}
+
+/**
+ * State logic for an auto-saving text field: holds the in-flight edit locally,
+ * commits on blur (with empty-input rollback), and — crucially — re-syncs to the
+ * latest `value` prop whenever the user is *not* actively editing. That last part
+ * is what removes the stale-`useState(initial)` hazard the ad-hoc fields had.
+ *
+ * Returns a binding to spread onto an `<input>`/`<textarea>`. `T` should be a
+ * primitive (string/number); supply `format`/`parse` for non-string values.
+ */
+export function useAutoSaveField<T>({
+  value,
+  onCommit,
+  format = defaultFormat,
+  parse = (input) => input as unknown as T,
+  trim = true,
+  rollbackWhenEmpty = true,
+}: UseAutoSaveFieldOptions<T>): AutoSaveFieldBinding {
+  const [draft, setDraft] = useState(() => format(value))
+  const editingRef = useRef(false)
+
+  // Latest helpers, read inside the re-sync effect without making it a dependency.
+  const formatRef = useRef(format)
+  formatRef.current = format
+
+  // Re-sync to the source value when it changes and the user isn't editing.
+  // While focused, the in-flight draft is preserved so a background refresh
+  // (multi-device sync, optimistic revert) can't clobber what's being typed.
+  useEffect(() => {
+    if (!editingRef.current) setDraft(formatRef.current(value))
+  }, [value])
+
+  return {
+    value: draft,
+    onChange: (e) => setDraft(e.target.value),
+    onFocus: () => {
+      editingRef.current = true
+    },
+    onBlur: () => {
+      editingRef.current = false
+      const raw = trim ? draft.trim() : draft
+      if (rollbackWhenEmpty && raw === '') {
+        setDraft(format(value))
+        return
+      }
+      const next = parse(raw)
+      if (next !== value) onCommit(next)
+      // Normalize the display to the committed value (e.g. "07" -> "7", trimmed).
+      setDraft(format(next))
+    },
+  }
+}


### PR DESCRIPTION
Closes #171. Phase 0 PR 5.

## Problem

Several template-editor fields held `useState(initialValue)` that never re-syncs to incoming props. In today's call paths the local state stays consistent (server state only changes via the field's own blur), but it's brittle: any future path that mutates the same field elsewhere — multi-device sync, an external action triggering a refresh, an optimistic update reverting — would surface stale local state.

## The primitive

**`useAutoSaveField<T>`** (`components/ui/useAutoSaveField.ts`) — owns the field state logic:
- Holds the in-flight edit locally
- Commits on blur, only when the parsed value changed
- Rolls back to the source value when emptied (configurable)
- **Re-syncs to the latest `value` prop whenever the user isn't editing** — the part that removes the stale-state hazard. While focused, the draft is preserved so a background refresh can't clobber what's being typed.
- Generic over `T` via `format`/`parse` (defaults handle strings; numbers pass a parser)

**`AutoSaveInput` / `AutoSaveTextarea`** — thin, style-agnostic string components wrapping the hook (`className` passthrough, so no visual change to the pre-retone fields).

## Refactors — every ad-hoc field now uses it

| Field | How |
|-------|-----|
| `BlockRow` name | `AutoSaveInput` |
| `SectionCard` name | `AutoSaveInput` |
| `SectionCard` duration | `useAutoSaveField<number>` with parse/clamp (`Math.max(0, parseInt ‖ 0)`), `rollbackWhenEmpty={false}` |
| `PlanNameField` | `AutoSaveInput` |
| `SessionFocusField` | `AutoSaveInput` with `trim={false}` + `rollbackWhenEmpty={false}` (focus is optional/clearable) |
| `SessionRenameRow` | `AutoSaveInput` |

Behavior is preserved per-field; the only semantic change is the new prop re-sync (the point of the issue).

## Acceptance criteria (#171)

- [x] One reusable primitive replaces the ad-hoc `useState(initial)` pattern in `BlockRow`, `SectionCard`, and the inline subcomponents in `/plans/[id]/page.tsx`
- [x] Stale-state edge cases (concurrent edit elsewhere) are no longer possible — covered by the "preserves draft mid-edit" and "re-syncs when not editing" tests

## Tests / verification

- New `AutoSaveInput.test.tsx` (10 tests): initial render, trimmed commit-on-blur, no-commit-when-unchanged, empty rollback, `trim={false}`/`rollbackWhenEmpty={false}` empty-commit, re-sync on prop change, draft preserved mid-edit, textarea, and the numeric hook path (parse/clamp/normalize + commit-0-on-empty).
- Full suite **91/91**, `npm run lint` clean, `tsc --noEmit` clean, dev server compiles.

## Notes

- **Optional debounce / "saving…" indicator left out** — no current field debounces (all commit on blur); easy to add later if a consumer needs it.
- Style-agnostic by design: no retone here (that's Phase 0 PR 9+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)